### PR TITLE
Add Studio MP4 export pipeline and API (youtube/shorts/video presets)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -61,6 +61,7 @@ from .civitai import (
 
 # Studio module routes
 from .studio.routes import router as studio_router
+from .studio.video_export import router as studio_video_export_router
 from .studio.repo import init_studio_db
 
 # Upscale module routes
@@ -132,6 +133,7 @@ app.add_middleware(
 
 # Include Studio routes (/studio/*)
 app.include_router(studio_router)
+app.include_router(studio_video_export_router)
 
 # Include Upscale routes (/v1/upscale)
 app.include_router(upscale_router)

--- a/backend/app/studio/exporter.py
+++ b/backend/app/studio/exporter.py
@@ -14,14 +14,13 @@ Mature content exports may have additional restrictions.
 """
 from __future__ import annotations
 
-import io
-import json
 import time
-import zipfile
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict
 
-from .repo import get_video, get_project, list_assets, list_scenes
+from .repo import get_video, get_project, list_assets, list_audio_tracks, list_captions
 from .audit import log_event
+from ..config import PUBLIC_BASE_URL
+from .video_export.composer import compose_project_export
 
 
 # Export targets that are NOT allowed (safety baseline)
@@ -332,6 +331,94 @@ def export_project_assets_zip(project_id: str, actor: str = "system") -> Dict[st
     }
 
 
+def _build_project_render_payload(project_id: str) -> Dict[str, Any]:
+    """Build a render-friendly payload from current project records."""
+    proj = get_project(project_id)
+    if not proj:
+        return {}
+
+    assets = sorted(list_assets(project_id), key=lambda a: a.createdAt)
+    tracks = list_audio_tracks(project_id)
+    captions = sorted(list_captions(project_id), key=lambda c: c.startSec)
+
+    media_assets = [a for a in assets if a.kind in ("video", "image")]
+    if not media_assets:
+        media_assets = assets
+
+    scene_count = max(len(media_assets), 1)
+    default_duration = max(2.0, float((proj.targetDurationSec or (scene_count * 4)) / scene_count))
+
+    scenes = []
+    for i, asset in enumerate(media_assets, start=1):
+        scene: Dict[str, Any] = {
+            "id": f"scene_{i}",
+            "title": asset.filename,
+            "durationSec": default_duration,
+        }
+        if asset.kind == "video":
+            scene["videoUrl"] = asset.url
+        elif asset.kind == "image":
+            scene["imageUrl"] = asset.url
+        else:
+            continue
+        if i <= len(captions):
+            scene["subtitle_text"] = captions[i - 1].text
+        scenes.append(scene)
+
+    voice_track = next((t for t in tracks if t.kind == "voiceover" and t.url), None)
+    music_track = next((t for t in tracks if t.kind == "music" and t.url), None)
+
+    payload = proj.model_dump()
+    payload["scenes"] = scenes
+    if voice_track and voice_track.url:
+        payload["voiceover_url"] = voice_track.url
+    if music_track and music_track.url:
+        payload["music_url"] = music_track.url
+    return payload
+
+
+def export_project_video_mp4(project_id: str, actor: str = "system") -> Dict[str, Any]:
+    """Export project as generic MP4 video."""
+    proj = get_project(project_id)
+    if not proj:
+        return {"ok": False, "error": "Project not found"}
+    payload = _build_project_render_payload(project_id)
+    try:
+        result = compose_project_export(project_id, payload, "video_mp4", PUBLIC_BASE_URL or "http://localhost:8000")
+    except Exception as exc:
+        return {"ok": False, "error": f"video_mp4 export failed: {exc}"}
+    log_event(project_id, "export_video_mp4", {"projectType": proj.projectType}, actor=actor)
+    return {"ok": True, "projectId": project_id, "kind": "video_mp4", "export": result.to_dict()}
+
+
+def export_project_youtube_mp4(project_id: str, actor: str = "system") -> Dict[str, Any]:
+    """Export project as YouTube 16:9 MP4."""
+    proj = get_project(project_id)
+    if not proj:
+        return {"ok": False, "error": "Project not found"}
+    payload = _build_project_render_payload(project_id)
+    try:
+        result = compose_project_export(project_id, payload, "youtube_mp4", PUBLIC_BASE_URL or "http://localhost:8000")
+    except Exception as exc:
+        return {"ok": False, "error": f"youtube_mp4 export failed: {exc}"}
+    log_event(project_id, "export_youtube_mp4", {"projectType": proj.projectType}, actor=actor)
+    return {"ok": True, "projectId": project_id, "kind": "youtube_mp4", "export": result.to_dict()}
+
+
+def export_project_shorts_mp4(project_id: str, actor: str = "system") -> Dict[str, Any]:
+    """Export project as YouTube Shorts 9:16 MP4."""
+    proj = get_project(project_id)
+    if not proj:
+        return {"ok": False, "error": "Project not found"}
+    payload = _build_project_render_payload(project_id)
+    try:
+        result = compose_project_export(project_id, payload, "shorts_mp4", PUBLIC_BASE_URL or "http://localhost:8000")
+    except Exception as exc:
+        return {"ok": False, "error": f"shorts_mp4 export failed: {exc}"}
+    log_event(project_id, "export_shorts_mp4", {"projectType": proj.projectType}, actor=actor)
+    return {"ok": True, "projectId": project_id, "kind": "shorts_mp4", "export": result.to_dict()}
+
+
 def get_project_available_exports(project_id: str) -> Dict[str, Any]:
     """Get list of available export formats for a professional project."""
     proj = get_project(project_id)
@@ -346,6 +433,9 @@ def get_project_available_exports(project_id: str) -> Dict[str, Any]:
         {"kind": "zip_assets", "label": "Asset Pack (ZIP)", "available": True},
         {"kind": "slides_pdf", "label": "Slides (PDF)", "available": is_slides},
         {"kind": "slides_pptx", "label": "Slides (PowerPoint)", "available": is_slides},
+        {"kind": "video_mp4", "label": "Video (MP4)", "available": True},
+        {"kind": "youtube_mp4", "label": "YouTube Video (MP4)", "available": True},
+        {"kind": "shorts_mp4", "label": "YouTube Shorts (MP4)", "available": True},
     ]
 
     return {
@@ -379,6 +469,9 @@ def export_project(
         "slides_pdf": export_project_slides_pdf,
         "slides_pptx": export_project_slides_pptx,
         "zip_assets": export_project_assets_zip,
+        "video_mp4": export_project_video_mp4,
+        "youtube_mp4": export_project_youtube_mp4,
+        "shorts_mp4": export_project_shorts_mp4,
     }
 
     exporter = exporters.get(kind)

--- a/backend/app/studio/routes.py
+++ b/backend/app/studio/routes.py
@@ -2297,7 +2297,16 @@ def project_available_exports(project_id: str):
 
 class ProjectExportRequest(BaseModel):
     """Request to export a professional project."""
-    kind: Literal["json_metadata", "storyboard_pdf", "slides_pdf", "slides_pptx", "zip_assets"] = "json_metadata"
+    kind: Literal[
+        "json_metadata",
+        "storyboard_pdf",
+        "slides_pdf",
+        "slides_pptx",
+        "zip_assets",
+        "video_mp4",
+        "youtube_mp4",
+        "shorts_mp4",
+    ] = "json_metadata"
 
 
 @router.post("/projects/{project_id}/export")

--- a/backend/app/studio/video_export/__init__.py
+++ b/backend/app/studio/video_export/__init__.py
@@ -1,0 +1,3 @@
+from .routes import router
+
+__all__ = ["router"]

--- a/backend/app/studio/video_export/adapters.py
+++ b/backend/app/studio/video_export/adapters.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def normalize_project_type(raw: str | None) -> str:
+    raw = (raw or "").strip().lower()
+    mapping = {
+        "video": "youtube_video",
+        "slideshow": "slides",
+        "video_series": "youtube_video",
+    }
+    return mapping.get(raw, raw or "youtube_video")
+
+
+def extract_project_type(project: dict[str, Any]) -> str:
+    for key in ("projectType", "type", "project_type", "kind", "content_type"):
+        if key in project and project[key]:
+            return normalize_project_type(str(project[key]))
+    return "youtube_video"
+
+
+def list_project_scenes(project: dict[str, Any]) -> list[dict[str, Any]]:
+    for key in ("scenes", "outline_scenes", "storyboard", "items"):
+        value = project.get(key)
+        if isinstance(value, list):
+            return [x for x in value if isinstance(x, dict)]
+    return []
+
+
+def project_voiceover_url(project: dict[str, Any]) -> str | None:
+    for key in ("voiceover_url", "narration_url", "audio_url"):
+        val = project.get(key)
+        if isinstance(val, str) and val:
+            return val
+    return None
+
+
+def project_music_url(project: dict[str, Any]) -> str | None:
+    for key in ("music_url", "bg_music_url", "background_music_url"):
+        val = project.get(key)
+        if isinstance(val, str) and val:
+            return val
+    return None
+
+
+def scene_media_url(scene: dict[str, Any]) -> tuple[str | None, str | None]:
+    video_keys = ("video_url", "videoUrl", "clip_url", "media_url")
+    image_keys = ("image_url", "imageUrl", "poster_url", "thumbnail_url")
+
+    video_url = next((scene.get(k) for k in video_keys if isinstance(scene.get(k), str) and scene.get(k)), None)
+    image_url = next((scene.get(k) for k in image_keys if isinstance(scene.get(k), str) and scene.get(k)), None)
+    return video_url, image_url
+
+
+def scene_duration_sec(scene: dict[str, Any], default: float = 4.0) -> float:
+    for key in ("durationSec", "duration_sec", "duration", "seconds", "clip_seconds"):
+        val = scene.get(key)
+        try:
+            if val is not None:
+                return max(0.5, float(val))
+        except Exception:
+            pass
+    return default
+
+
+def scene_title(scene: dict[str, Any], index: int) -> str:
+    return str(scene.get("title") or scene.get("name") or f"Scene {index + 1}")
+
+
+def scene_effect(scene: dict[str, Any], fallback: str = "ken_burns") -> str:
+    val = str(scene.get("effect") or scene.get("motion_effect") or fallback).strip().lower()
+    return "ken_burns" if val in {"ken_burns", "kenburns", "pan_zoom"} else "none"
+
+
+def scene_subtitle_text(scene: dict[str, Any]) -> str:
+    for key in ("subtitle_text", "caption", "text", "narration", "voiceover_text"):
+        val = scene.get(key)
+        if isinstance(val, str) and val.strip():
+            return val.strip()
+    return ""

--- a/backend/app/studio/video_export/composer.py
+++ b/backend/app/studio/video_export/composer.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import shutil
+import uuid
+from pathlib import Path
+from typing import Any
+
+from .fetch import materialize_remote_source
+from .ffmpeg import (
+    burn_subtitles,
+    concat_videos,
+    extract_thumbnail,
+    media_duration_sec,
+    mux_audio,
+    normalize_video_clip,
+    render_image_clip,
+    write_srt,
+)
+from .manifest import write_manifest
+from .models import ExportKind, ExportResult
+from .paths import make_working_files
+from .planner import build_timeline_plan
+from .presets import get_preset
+
+
+def _safe_stem(text: str) -> str:
+    chars = []
+    for ch in text:
+        if ch.isalnum() or ch in ("-", "_"):
+            chars.append(ch)
+        elif ch.isspace():
+            chars.append("_")
+    return "".join(chars)[:80] or "asset"
+
+
+def compose_project_export(
+    project_id: str,
+    project: dict[str, Any],
+    export_kind: ExportKind,
+    public_base_url: str,
+) -> ExportResult:
+    export_id = uuid.uuid4().hex
+    preset = get_preset(export_kind)
+    wf = make_working_files(project_id, export_id=export_id)
+
+    plan = build_timeline_plan(project_id=project_id, project=project, export_kind=export_kind)
+
+    rendered_clips: list[Path] = []
+    for idx, scene in enumerate(plan.scenes):
+        if not scene.source_url:
+            continue
+
+        source_local = materialize_remote_source(
+            url=scene.source_url,
+            dest_dir=wf.sources_dir,
+            stem=f"{idx:03d}_{_safe_stem(scene.title)}",
+        )
+
+        clip_out = wf.renders_dir / f"{idx:03d}_clip.mp4"
+        if scene.kind == "video":
+            normalize_video_clip(source_local, clip_out, preset)
+        else:
+            render_image_clip(
+                image_path=source_local,
+                output_path=clip_out,
+                duration_sec=scene.duration_sec,
+                preset=preset,
+                effect=scene.effect,
+            )
+        rendered_clips.append(clip_out)
+
+    if not rendered_clips:
+        raise ValueError("No renderable scenes found for export")
+
+    wf.concat_list_path.write_text(
+        "".join(f"file '{clip.resolve().as_posix()}'\n" for clip in rendered_clips),
+        encoding="utf-8",
+    )
+
+    stitched_path = wf.workdir / "stitched.mp4"
+    concat_videos(wf.concat_list_path, stitched_path, preset)
+
+    voiceover_local = None
+    music_local = None
+    if plan.voiceover_url:
+        voiceover_local = materialize_remote_source(plan.voiceover_url, wf.sources_dir, "voiceover")
+    if plan.music_url:
+        music_local = materialize_remote_source(plan.music_url, wf.sources_dir, "music")
+
+    muxed_path = wf.workdir / "muxed.mp4"
+    mux_audio(
+        video_path=stitched_path,
+        output_path=muxed_path,
+        voiceover_path=voiceover_local,
+        music_path=music_local,
+        preset=preset,
+    )
+
+    final_path = wf.final_output_path
+    if plan.subtitle_items:
+        write_srt(plan.subtitle_items, wf.subtitles_path)
+        burn_subtitles(muxed_path, wf.subtitles_path, final_path, preset)
+    else:
+        shutil.copyfile(muxed_path, final_path)
+
+    extract_thumbnail(final_path, wf.thumbnail_path)
+    duration_sec = media_duration_sec(final_path)
+
+    output_url = f"{public_base_url.rstrip('/')}/studio/exports/{project_id}/{export_id}/final.mp4"
+    thumbnail_url = f"{public_base_url.rstrip('/')}/studio/exports/{project_id}/{export_id}/thumbnail.jpg"
+
+    write_manifest(
+        wf.manifest_path,
+        {
+            "export_id": export_id,
+            "project_id": project_id,
+            "kind": export_kind,
+            "preset": preset.name,
+            "plan": plan.to_dict(),
+            "artifacts": {
+                "final_output_path": str(final_path),
+                "thumbnail_path": str(wf.thumbnail_path),
+            },
+            "duration_sec": duration_sec,
+        },
+    )
+
+    return ExportResult(
+        export_id=export_id,
+        project_id=project_id,
+        kind=export_kind,
+        status="ready",
+        output_path=str(final_path),
+        output_url=output_url,
+        thumbnail_path=str(wf.thumbnail_path),
+        thumbnail_url=thumbnail_url,
+        manifest_path=str(wf.manifest_path),
+        duration_sec=duration_sec,
+        width=preset.width,
+        height=preset.height,
+        fps=preset.fps,
+        message="Export completed",
+    )

--- a/backend/app/studio/video_export/fetch.py
+++ b/backend/app/studio/video_export/fetch.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import mimetypes
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+
+
+def infer_extension_from_url(url: str, fallback: str = ".bin") -> str:
+    parsed = urlparse(url)
+    qs = parse_qs(parsed.query)
+    filename = (qs.get("filename") or [""])[0]
+    if filename:
+        ext = Path(filename).suffix
+        if ext:
+            return ext.lower()
+
+    ext = Path(parsed.path).suffix
+    if ext:
+        return ext.lower()
+
+    mime, _ = mimetypes.guess_type(url)
+    if mime:
+        guessed = mimetypes.guess_extension(mime)
+        if guessed:
+            return guessed.lower()
+
+    return fallback
+
+
+def download_to_path(url: str, dest: Path, timeout_sec: float = 60.0) -> Path:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    timeout = httpx.Timeout(timeout_sec, connect=min(10.0, timeout_sec))
+    with httpx.Client(timeout=timeout, follow_redirects=True) as client:
+        r = client.get(url)
+        r.raise_for_status()
+        with dest.open("wb") as f:
+            for chunk in r.iter_bytes():
+                if chunk:
+                    f.write(chunk)
+    return dest
+
+
+def materialize_remote_source(url: str, dest_dir: Path, stem: str) -> Path:
+    ext = infer_extension_from_url(url, fallback=".dat")
+    dest = dest_dir / f"{stem}{ext}"
+    return download_to_path(url, dest)

--- a/backend/app/studio/video_export/ffmpeg.py
+++ b/backend/app/studio/video_export/ffmpeg.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+from .models import ExportPreset
+
+
+class FFmpegError(RuntimeError):
+    pass
+
+
+def run_ffmpeg(args: list[str]) -> None:
+    cmd = ["ffmpeg", "-y", *args]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise FFmpegError(proc.stderr.strip() or proc.stdout.strip())
+
+
+def run_ffprobe_json(path: str | Path) -> dict:
+    cmd = [
+        "ffprobe",
+        "-v",
+        "error",
+        "-print_format",
+        "json",
+        "-show_format",
+        "-show_streams",
+        str(path),
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise FFmpegError(proc.stderr.strip() or proc.stdout.strip())
+    return json.loads(proc.stdout)
+
+
+def media_duration_sec(path: str | Path) -> float:
+    info = run_ffprobe_json(path)
+    fmt = info.get("format", {})
+    try:
+        return float(fmt.get("duration", 0.0))
+    except Exception:
+        return 0.0
+
+
+def detect_has_audio(path: str | Path) -> bool:
+    info = run_ffprobe_json(path)
+    streams = info.get("streams", [])
+    return any(s.get("codec_type") == "audio" for s in streams)
+
+
+def make_scale_pad_filter(width: int, height: int, background_color: str = "black") -> str:
+    return (
+        f"scale={width}:{height}:force_original_aspect_ratio=decrease,"
+        f"pad={width}:{height}:(ow-iw)/2:(oh-ih)/2:{background_color}"
+    )
+
+
+def render_image_clip(
+    image_path: str | Path,
+    output_path: str | Path,
+    duration_sec: float,
+    preset: ExportPreset,
+    effect: str = "ken_burns",
+) -> None:
+    vf_base = make_scale_pad_filter(preset.width, preset.height, preset.background_color)
+    if effect == "ken_burns":
+        vf = (
+            f"{vf_base},"
+            f"zoompan=z='min(zoom+0.0008,1.08)':d={int(duration_sec * preset.fps)}:"
+            f"x='iw/2-(iw/zoom/2)':y='ih/2-(ih/zoom/2)':s={preset.width}x{preset.height},"
+            f"fps={preset.fps}"
+        )
+    else:
+        vf = f"{vf_base},fps={preset.fps}"
+
+    args = [
+        "-loop",
+        "1",
+        "-i",
+        str(image_path),
+        "-t",
+        f"{duration_sec:.3f}",
+        "-vf",
+        vf,
+        *preset.to_ffmpeg_args(),
+        "-an",
+        str(output_path),
+    ]
+    run_ffmpeg(args)
+
+
+def normalize_video_clip(video_path: str | Path, output_path: str | Path, preset: ExportPreset) -> None:
+    vf = make_scale_pad_filter(preset.width, preset.height, preset.background_color)
+    args = [
+        "-i",
+        str(video_path),
+        "-vf",
+        f"{vf},fps={preset.fps}",
+        *preset.to_ffmpeg_args(),
+        str(output_path),
+    ]
+    run_ffmpeg(args)
+
+
+def concat_videos(concat_list_path: str | Path, output_path: str | Path, preset: ExportPreset) -> None:
+    args = [
+        "-f",
+        "concat",
+        "-safe",
+        "0",
+        "-i",
+        str(concat_list_path),
+        "-c:v",
+        preset.video_codec,
+        "-crf",
+        str(preset.crf),
+        "-preset",
+        preset.preset,
+        "-pix_fmt",
+        preset.pix_fmt,
+        "-movflags",
+        preset.movflags,
+        "-c:a",
+        preset.audio_codec,
+        "-b:a",
+        preset.audio_bitrate,
+        "-ar",
+        str(preset.sample_rate),
+        str(output_path),
+    ]
+    run_ffmpeg(args)
+
+
+def mux_audio(
+    video_path: str | Path,
+    output_path: str | Path,
+    voiceover_path: Optional[str | Path] = None,
+    music_path: Optional[str | Path] = None,
+    preset: Optional[ExportPreset] = None,
+) -> None:
+    if not voiceover_path and not music_path:
+        shutil.copyfile(video_path, output_path)
+        return
+
+    inputs = ["-i", str(video_path)]
+    audio_inputs: list[tuple[int, float]] = []
+    input_index = 1
+
+    if voiceover_path:
+        inputs += ["-i", str(voiceover_path)]
+        audio_inputs.append((input_index, 1.0))
+        input_index += 1
+
+    if music_path:
+        inputs += ["-i", str(music_path)]
+        audio_inputs.append((input_index, 0.25))
+
+    if len(audio_inputs) == 1:
+        idx, volume = audio_inputs[0]
+        filter_complex = f"[{idx}:a]volume={volume}[aout]"
+    else:
+        chains = []
+        mix_inputs = []
+        for i, volume in audio_inputs:
+            name = f"a{i}"
+            chains.append(f"[{i}:a]volume={volume}[{name}]")
+            mix_inputs.append(f"[{name}]")
+        filter_complex = ";".join(chains) + ";" + "".join(mix_inputs) + f"amix=inputs={len(audio_inputs)}:normalize=0[aout]"
+
+    args = [
+        *inputs,
+        "-filter_complex",
+        filter_complex,
+        "-map",
+        "0:v:0",
+        "-map",
+        "[aout]",
+        "-shortest",
+        "-c:v",
+        "copy",
+        "-c:a",
+        preset.audio_codec if preset else "aac",
+        "-b:a",
+        preset.audio_bitrate if preset else "192k",
+        str(output_path),
+    ]
+    run_ffmpeg(args)
+
+
+def write_srt(subtitle_items: list[dict], output_path: str | Path) -> None:
+    def fmt_time(sec: float) -> str:
+        h = int(sec // 3600)
+        m = int((sec % 3600) // 60)
+        s = int(sec % 60)
+        ms = int(round((sec - int(sec)) * 1000))
+        return f"{h:02d}:{m:02d}:{s:02d},{ms:03d}"
+
+    lines: list[str] = []
+    for i, item in enumerate(subtitle_items, start=1):
+        start = float(item.get("start", 0.0))
+        end = float(item.get("end", 0.0))
+        text = str(item.get("text", "")).strip()
+        if not text:
+            continue
+        lines.extend([str(i), f"{fmt_time(start)} --> {fmt_time(end)}", text, ""])
+
+    Path(output_path).write_text("\n".join(lines), encoding="utf-8")
+
+
+def burn_subtitles(video_path: str | Path, srt_path: str | Path, output_path: str | Path, preset: ExportPreset) -> None:
+    safe_srt = str(srt_path).replace("\\", "/").replace(":", r"\:")
+    args = [
+        "-i",
+        str(video_path),
+        "-vf",
+        f"subtitles={safe_srt}",
+        *preset.to_ffmpeg_args(),
+        str(output_path),
+    ]
+    run_ffmpeg(args)
+
+
+def extract_thumbnail(video_path: str | Path, output_path: str | Path, timestamp_sec: float = 0.2) -> None:
+    args = [
+        "-ss",
+        f"{timestamp_sec:.3f}",
+        "-i",
+        str(video_path),
+        "-frames:v",
+        "1",
+        "-q:v",
+        "2",
+        str(output_path),
+    ]
+    run_ffmpeg(args)

--- a/backend/app/studio/video_export/manifest.py
+++ b/backend/app/studio/video_export/manifest.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+
+def write_manifest(path: Path, payload: dict[str, Any]) -> None:
+    payload = {
+        **payload,
+        "written_at": time.time(),
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")

--- a/backend/app/studio/video_export/models.py
+++ b/backend/app/studio/video_export/models.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Literal, Optional
+
+ProjectType = Literal["video", "slideshow", "video_series", "youtube_video", "youtube_short", "slides"]
+ExportKind = Literal["video_mp4", "youtube_mp4", "shorts_mp4"]
+
+
+@dataclass
+class SceneSource:
+    scene_id: str
+    title: str = ""
+    kind: Literal["video", "image"] = "image"
+    source_url: str = ""
+    duration_sec: float = 4.0
+    transition_sec: float = 0.25
+    narration_url: Optional[str] = None
+    music_url: Optional[str] = None
+    subtitle_text: str = ""
+    effect: Literal["none", "ken_burns"] = "none"
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class TimelinePlan:
+    project_id: str
+    project_type: ProjectType
+    export_kind: ExportKind
+    width: int
+    height: int
+    fps: int
+    scenes: list[SceneSource] = field(default_factory=list)
+    voiceover_url: Optional[str] = None
+    music_url: Optional[str] = None
+    subtitle_items: list[dict[str, Any]] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "project_id": self.project_id,
+            "project_type": self.project_type,
+            "export_kind": self.export_kind,
+            "width": self.width,
+            "height": self.height,
+            "fps": self.fps,
+            "scenes": [asdict(s) for s in self.scenes],
+            "voiceover_url": self.voiceover_url,
+            "music_url": self.music_url,
+            "subtitle_items": self.subtitle_items,
+            "metadata": self.metadata,
+        }
+
+
+@dataclass
+class WorkingFiles:
+    workdir: Path
+    sources_dir: Path
+    renders_dir: Path
+    concat_list_path: Path
+    subtitles_path: Path
+    final_output_path: Path
+    thumbnail_path: Path
+    manifest_path: Path
+
+
+@dataclass
+class ExportPreset:
+    name: str
+    width: int
+    height: int
+    fps: int
+    video_codec: str = "libx264"
+    audio_codec: str = "aac"
+    crf: int = 18
+    preset: str = "medium"
+    pix_fmt: str = "yuv420p"
+    movflags: str = "+faststart"
+    audio_bitrate: str = "192k"
+    sample_rate: int = 48000
+    allow_letterbox: bool = True
+    background_color: str = "black"
+
+    def to_ffmpeg_args(self) -> list[str]:
+        return [
+            "-c:v",
+            self.video_codec,
+            "-crf",
+            str(self.crf),
+            "-preset",
+            self.preset,
+            "-pix_fmt",
+            self.pix_fmt,
+            "-movflags",
+            self.movflags,
+            "-c:a",
+            self.audio_codec,
+            "-b:a",
+            self.audio_bitrate,
+            "-ar",
+            str(self.sample_rate),
+        ]
+
+
+@dataclass
+class ExportResult:
+    export_id: str
+    project_id: str
+    kind: ExportKind
+    status: Literal["ready", "error"]
+    output_path: str
+    output_url: str
+    thumbnail_path: Optional[str] = None
+    thumbnail_url: Optional[str] = None
+    manifest_path: Optional[str] = None
+    duration_sec: float = 0.0
+    width: int = 0
+    height: int = 0
+    fps: int = 0
+    message: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)

--- a/backend/app/studio/video_export/paths.py
+++ b/backend/app/studio/video_export/paths.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+from .models import WorkingFiles
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[4]
+
+
+def studio_exports_root() -> Path:
+    p = repo_root() / "backend" / "data" / "studio_exports"
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def files_public_root() -> Path:
+    p = repo_root() / "backend" / "data" / "uploads"
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def make_working_files(project_id: str, export_id: str | None = None) -> WorkingFiles:
+    export_id = export_id or uuid.uuid4().hex
+    workdir = studio_exports_root() / project_id / export_id
+    sources = workdir / "sources"
+    renders = workdir / "renders"
+    sources.mkdir(parents=True, exist_ok=True)
+    renders.mkdir(parents=True, exist_ok=True)
+
+    return WorkingFiles(
+        workdir=workdir,
+        sources_dir=sources,
+        renders_dir=renders,
+        concat_list_path=workdir / "concat.txt",
+        subtitles_path=workdir / "subtitles.srt",
+        final_output_path=workdir / "final.mp4",
+        thumbnail_path=workdir / "thumbnail.jpg",
+        manifest_path=workdir / "export_manifest.json",
+    )

--- a/backend/app/studio/video_export/planner.py
+++ b/backend/app/studio/video_export/planner.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+from .adapters import (
+    extract_project_type,
+    list_project_scenes,
+    project_music_url,
+    project_voiceover_url,
+    scene_duration_sec,
+    scene_effect,
+    scene_media_url,
+    scene_subtitle_text,
+    scene_title,
+)
+from .models import ExportKind, ProjectType, SceneSource, TimelinePlan
+from .presets import get_preset
+
+
+def build_timeline_plan(project_id: str, project: dict[str, Any], export_kind: ExportKind) -> TimelinePlan:
+    project_type = extract_project_type(project)
+    preset = get_preset(export_kind)
+    raw_scenes = list_project_scenes(project)
+
+    scenes: list[SceneSource] = []
+    subtitle_items: list[dict[str, Any]] = []
+    cursor = 0.0
+
+    for i, raw in enumerate(raw_scenes):
+        video_url, image_url = scene_media_url(raw)
+        duration_sec = scene_duration_sec(raw, default=4.0)
+
+        if project_type == "slides":
+            kind = "image"
+            source_url = image_url or video_url or ""
+            effect = scene_effect(raw, fallback="ken_burns")
+        else:
+            if video_url:
+                kind = "video"
+                source_url = video_url
+                effect = "none"
+            else:
+                kind = "image"
+                source_url = image_url or ""
+                effect = scene_effect(raw, fallback="ken_burns")
+
+        scene = SceneSource(
+            scene_id=str(raw.get("id") or f"scene_{i+1}"),
+            title=scene_title(raw, i),
+            kind=kind,
+            source_url=source_url,
+            duration_sec=duration_sec,
+            transition_sec=float(raw.get("transition_sec") or 0.25),
+            narration_url=raw.get("narration_url") or raw.get("voiceover_url"),
+            music_url=raw.get("music_url"),
+            subtitle_text=scene_subtitle_text(raw),
+            effect=effect,
+            metadata=raw,
+        )
+        scenes.append(scene)
+
+        if scene.subtitle_text:
+            subtitle_items.append({"start": cursor, "end": cursor + duration_sec, "text": scene.subtitle_text})
+        cursor += duration_sec
+
+    return TimelinePlan(
+        project_id=project_id,
+        project_type=cast(ProjectType, project_type),
+        export_kind=export_kind,
+        width=preset.width,
+        height=preset.height,
+        fps=preset.fps,
+        scenes=scenes,
+        voiceover_url=project_voiceover_url(project),
+        music_url=project_music_url(project),
+        subtitle_items=subtitle_items,
+        metadata={
+            "scene_count": len(scenes),
+            "title": project.get("title") or project.get("name") or "Untitled Project",
+        },
+    )

--- a/backend/app/studio/video_export/presets.py
+++ b/backend/app/studio/video_export/presets.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from .models import ExportKind, ExportPreset
+
+YOUTUBE_MP4 = ExportPreset(
+    name="youtube_mp4",
+    width=1920,
+    height=1080,
+    fps=30,
+    crf=18,
+    preset="medium",
+)
+
+SHORTS_MP4 = ExportPreset(
+    name="shorts_mp4",
+    width=1080,
+    height=1920,
+    fps=30,
+    crf=18,
+    preset="medium",
+)
+
+VIDEO_MP4 = ExportPreset(
+    name="video_mp4",
+    width=1280,
+    height=720,
+    fps=30,
+    crf=18,
+    preset="medium",
+)
+
+PRESETS: dict[ExportKind, ExportPreset] = {
+    "video_mp4": VIDEO_MP4,
+    "youtube_mp4": YOUTUBE_MP4,
+    "shorts_mp4": SHORTS_MP4,
+}
+
+
+def get_preset(kind: ExportKind) -> ExportPreset:
+    return PRESETS[kind]

--- a/backend/app/studio/video_export/routes.py
+++ b/backend/app/studio/video_export/routes.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import FileResponse
+from pydantic import BaseModel, Field
+
+from .composer import compose_project_export
+from .paths import studio_exports_root
+
+router = APIRouter(prefix="/studio/video-export", tags=["studio-video-export"])
+
+
+class StudioVideoExportIn(BaseModel):
+    project_id: str = Field(..., description="Creator Studio project id")
+    project: dict[str, Any] = Field(..., description="Project payload including scenes")
+    kind: Literal["video_mp4", "youtube_mp4", "shorts_mp4"] = "youtube_mp4"
+    public_base_url: str = Field("http://localhost:8000", description="Public backend base URL")
+
+
+@router.post("")
+def export_studio_project_video(inp: StudioVideoExportIn) -> dict[str, Any]:
+    try:
+        result = compose_project_export(
+            project_id=inp.project_id,
+            project=inp.project,
+            export_kind=inp.kind,
+            public_base_url=inp.public_base_url,
+        )
+        return {"ok": True, "export": result.to_dict()}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Studio export failed: {e}")
+
+
+@router.get("/files/{project_id}/{export_id}/final.mp4")
+def get_exported_video(project_id: str, export_id: str):
+    path = studio_exports_root() / project_id / export_id / "final.mp4"
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="Exported video not found")
+    return FileResponse(path, media_type="video/mp4", filename=f"{project_id}-{export_id}.mp4")
+
+
+@router.get("/files/{project_id}/{export_id}/thumbnail.jpg")
+def get_exported_thumbnail(project_id: str, export_id: str):
+    path = studio_exports_root() / project_id / export_id / "thumbnail.jpg"
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="Exported thumbnail not found")
+    return FileResponse(path, media_type="image/jpeg", filename=f"{project_id}-{export_id}.jpg")

--- a/plans/creator-studio-mp4-export-backend-plan.md
+++ b/plans/creator-studio-mp4-export-backend-plan.md
@@ -1,0 +1,183 @@
+# Creator Studio Backend Upgrade Plan: Additive MP4 Export for YouTube
+
+## 1) Goal and constraints
+
+Build a **backend-only, additive, non-destructive** upgrade that enables real MP4 export for Creator Studio projects while preserving existing routes and current export formats.
+
+### Explicit constraints
+- Keep existing API surface (`/studio/projects/{project_id}/exports` and `/studio/projects/{project_id}/export`) intact.
+- Add new export kinds instead of replacing old ones.
+- Keep existing JSON/PDF/PPTX/ZIP export behavior unchanged.
+- Keep orchestration in `backend/app/studio/exporter.py` and isolate rendering internals in a new module.
+
+## 2) Current-state findings (what blocks MP4 today)
+
+1. Project export request kind list only supports metadata/doc/asset pack outputs.
+2. `export_project(...)` dispatch only points to placeholder-style exporters.
+3. No timeline planning, media normalization, composition, or ffmpeg render path exists for project exports.
+4. There is an existing `media/app.py` service suitable for media operations; we can reuse it incrementally.
+
+## 3) Target architecture (additive)
+
+Create a new package:
+
+```text
+backend/app/studio/video_export/
+├── __init__.py
+├── composer.py     # top-level orchestration for final mp4
+├── planner.py      # normalize project+assets into timeline manifest
+├── presets.py      # output presets (youtube/shorts/generic)
+├── fetch.py        # remote URL -> local temp workspace
+├── ffmpeg.py       # ffmpeg command wrappers
+└── manifest.py     # export run metadata and status
+```
+
+### Responsibilities
+- `exporter.py`: validate kind, dispatch, return export contract.
+- `video_export.composer`: run planning/fetch/render pipeline.
+- `video_export.ffmpeg`: codec/filter/concat/mix primitives only.
+- `video_export.manifest`: store structured job metadata/logs/outcome for retrieval.
+
+## 4) API and model evolution plan
+
+## 4.1 Extend project export request kinds
+Add project export kinds:
+- `video_mp4` (generic final MP4)
+- `youtube_mp4` (16:9 optimized preset)
+- `shorts_mp4` (9:16 optimized preset)
+
+## 4.2 Extend `get_project_available_exports`
+Add availability rules:
+- Always offer `video_mp4`.
+- Offer `youtube_mp4` for `youtube_video` and convertible projects.
+- Offer `shorts_mp4` for `youtube_short` and convertible projects.
+- Keep existing exports exactly as-is.
+
+## 4.3 Preserve route contracts
+Do not add a new frontend flow. Keep:
+- `GET /studio/projects/{project_id}/exports`
+- `POST /studio/projects/{project_id}/export`
+
+Only extend accepted `kind` values and exporter dispatch.
+
+## 5) Project-type normalization plan
+
+Because frontend names (`video`, `slideshow`, `video_series`) differ from backend project types (`youtube_video`, `youtube_short`, `slides`), add an internal normalization layer:
+
+- `video` -> `youtube_video`
+- `slideshow` -> `slides`
+- `video_series` -> `youtube_video` + metadata tag `projectType:video_series`
+
+Normalization should be additive and backward compatible; no destructive schema migration required.
+
+## 6) Timeline planning design
+
+`planner.py` should output a normalized render spec:
+
+- Canvas: width/height/fps
+- Ordered scenes with per-scene source kind (`video` or `image`)
+- Duration resolution (scene-level override, fallback defaults)
+- Audio tracks (voice/music) and mix intent
+- Caption events/subtitles (optional in v1, required hooks)
+
+### Scene resolution rules
+1. If scene video exists: prefer video clip.
+2. Else if scene image exists: synthesize motion clip from still image.
+3. Else: produce a deterministic planner warning/error.
+
+## 7) Rendering strategy by project type
+
+### 7.1 Video Project
+- Use scene `videoUrl` when present.
+- Fallback to image clip generation when only `imageUrl` exists.
+- Concat clips in scene order.
+- Optional voice/music mix in phase 2.
+
+### 7.2 Slideshow
+- Convert each still into timed clip (hold or Ken Burns).
+- Apply optional transitions and concat.
+- Produce MP4 via same finalizer as other types.
+
+### 7.3 Video Series
+- v1: export current project into one MP4 via same pipeline.
+- v2+: episode-aware batch and compilation exports.
+
+## 8) ffmpeg/preset standards (YouTube-safe defaults)
+
+For v1 output:
+- Video codec: H.264 (`libx264`)
+- Audio codec: AAC
+- Pixel format: `yuv420p`
+- Fast start: `+faststart`
+- FPS normalization: 30 (configurable)
+
+Preset examples:
+- `youtube_mp4`: 1920x1080
+- `shorts_mp4`: 1080x1920
+- `video_mp4`: project canvas or safe fallback (e.g., 1280x720)
+
+## 9) Execution phases
+
+## Phase 1 (MVP: real MP4 export)
+1. Add new export kinds to project request model/route.
+2. Add new exporters in `exporter.py` and dispatch wiring.
+3. Implement `video_export` package with planner/fetch/ffmpeg/composer.
+4. Render scenes -> concat -> output MP4 file and URL.
+5. Record manifest (status, output path/url, basic logs).
+
+**Exit criteria:** A project can be exported as a playable MP4 via `POST /studio/projects/{id}/export`.
+
+## Phase 2 (quality + narration)
+1. Add narration/music mix support.
+2. Add subtitle generation hooks (sidecar `.srt`, optional burn-in).
+3. Add thumbnail generation and richer export metadata.
+
+**Exit criteria:** MP4 includes optional mixed audio and richer artifacts.
+
+## Phase 3 (series + scale)
+1. Add episode/batch series export modes.
+2. Add async/background job execution for long renders.
+3. Add retry and resumable workflow for fetch/render steps.
+
+**Exit criteria:** Reliable long-form/series exports with job lifecycle controls.
+
+## 10) Data contracts and observability
+
+Manifest fields to persist per export:
+- `exportId`, `projectId`, `kind`, `preset`, `status`
+- timestamps (`createdAt`, `startedAt`, `completedAt`)
+- derived media info (`durationSec`, resolution, fileSizeBytes)
+- output location (`outputPath`, `outputUrl`)
+- diagnostics (`warnings`, `logs`, `error`)
+
+Add audit events for start/success/failure with kind + project type.
+
+## 11) Testing and validation plan
+
+### Unit tests
+- Planner: scene fallback precedence, duration defaults, type normalization.
+- Presets: dimensions/fps/codec correctness.
+- Export dispatch: new kinds routed correctly.
+
+### Integration tests
+- API: `POST /studio/projects/{id}/export` for all 3 new kinds.
+- End-to-end with mixed scene assets (video + image-only fallback).
+- Failure handling for unreachable asset URLs.
+
+### Output validation checks
+- MP4 playable in common players.
+- `ffprobe` confirms codec/pixel format/fps.
+- Fast-start metadata present for streaming.
+
+## 12) Risk controls (non-destructive rollout)
+
+- Feature flag gate for MP4 export kinds in initial deployment.
+- Keep existing export kinds untouched and regression-tested.
+- Add clear error payloads when media dependencies are unavailable.
+- Support partial fallback behavior (e.g., image hold clip) instead of hard fail where possible.
+
+## 13) Immediate next implementation slice
+
+Start with **`youtube_mp4` only**, but implement reusable internals so `video_mp4` and `shorts_mp4` are thin preset variants.
+
+This gives one clear backend contract quickly while avoiding duplicate logic.


### PR DESCRIPTION
### Motivation
- Provide backend-native MP4 export for Creator Studio projects without changing existing export formats or routes, enabling YouTube/shorts/generic MP4 outputs.
- Implement a self-contained, additive video rendering pipeline that normalizes project payloads, fetches remote media, composes timelines, and uses `ffmpeg` to produce final artifacts.

### Description
- Add a new `backend/app/studio/video_export` package with modules: `composer.py`, `planner.py`, `presets.py`, `ffmpeg.py`, `fetch.py`, `adapters.py`, `models.py`, `paths.py`, `manifest.py`, and `routes.py` to orchestrate rendering, media materialization, timeline planning, ffmpeg primitives, and artifact manifesting.
- Extend the Studio exporter in `backend/app/studio/exporter.py` with a payload builder `_build_project_render_payload` and three new exporters `export_project_video_mp4`, `export_project_youtube_mp4`, and `export_project_shorts_mp4`, and wire them into the `export_project` dispatch map.
- Expand the public API by importing and including the new router in `backend/app/main.py` and extend `ProjectExportRequest` and `get_project_available_exports` in `backend/app/studio/routes.py` to accept and advertise the new `video_mp4`, `youtube_mp4`, and `shorts_mp4` kinds.
- Add `plans/creator-studio-mp4-export-backend-plan.md` documenting the design, constraints, and rollout plan for the MP4 export feature.

### Testing
- No automated tests were added or executed as part of this PR; the change introduces new modules and routes but does not include unit or integration test coverage in this commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d960e7eecc832db55835a80a6a8719)