### PR TITLE
Add DigitalOcean deployment and mature-content notices

### DIFF
--- a/.github/workflows/digitalocean.yml
+++ b/.github/workflows/digitalocean.yml
@@ -74,4 +74,4 @@ jobs:
           script: |
             cd /opt/homepilot
             sed -i 's|^HOMEPILOT_IMAGE=.*|HOMEPILOT_IMAGE=${{ needs.build.outputs.image_ref }}|' .env
-            ./deploy.sh
+            bash deploy.sh

--- a/.github/workflows/digitalocean.yml
+++ b/.github/workflows/digitalocean.yml
@@ -1,0 +1,77 @@
+name: DigitalOcean Web Deployment
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "digitalocean/**"
+      - "notifications/**"
+      - ".github/workflows/digitalocean.yml"
+  workflow_dispatch:
+    inputs:
+      deploy:
+        description: Deploy after publishing the image
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: digitalocean-production
+  cancel-in-progress: false
+
+env:
+  IMAGE: ghcr.io/${{ github.repository_owner }}/homepilot-digitalocean
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      image_ref: ${{ steps.image.outputs.ref }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: image
+        run: echo "ref=${IMAGE}:${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: digitalocean/Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: |
+            ${{ env.IMAGE }}:${{ github.sha }}
+            ${{ env.IMAGE }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    if: github.event_name == 'push' || inputs.deploy
+    needs: build
+    runs-on: ubuntu-latest
+    environment: digitalocean-production
+    steps:
+      - name: Deploy over SSH
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.DO_HOST }}
+          username: ${{ secrets.DO_USER }}
+          key: ${{ secrets.DO_SSH_PRIVATE_KEY }}
+          port: ${{ secrets.DO_SSH_PORT || 22 }}
+          script_stop: true
+          script: |
+            cd /opt/homepilot
+            sed -i 's|^HOMEPILOT_IMAGE=.*|HOMEPILOT_IMAGE=${{ needs.build.outputs.image_ref }}|' .env
+            ./deploy.sh

--- a/digitalocean/.env.example
+++ b/digitalocean/.env.example
@@ -1,0 +1,24 @@
+# Public hostname. Create an A/AAAA DNS record pointing to the Droplet first.
+HOMEPILOT_DOMAIN=homepilot.example.com
+ACME_EMAIL=admin@example.com
+
+# Image published by the GitHub workflow.
+HOMEPILOT_IMAGE=ghcr.io/ruslanmv/homepilot-digitalocean:latest
+HOMEPILOT_BIND_ADDRESS=127.0.0.1
+
+# Required application security. Generate with: openssl rand -hex 32
+API_KEY=replace-with-a-long-random-value
+
+# Use an external provider on a CPU Droplet.
+HOMEPILOT_LLM_BACKEND=openai
+OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
+
+# Hosted deployment identity.
+HOMEPILOT_EDITION=web
+PUBLIC_BASE_URL=https://homepilot.example.com
+
+# Optional feature controls.
+INTERACTIVE_ENABLED=true
+INTERACTIVE_PLAYBACK_LLM=false
+INTERACTIVE_PLAYBACK_RENDER=false

--- a/digitalocean/Caddyfile
+++ b/digitalocean/Caddyfile
@@ -1,0 +1,20 @@
+{$HOMEPILOT_DOMAIN} {
+  encode zstd gzip
+
+  reverse_proxy homepilot:7860 {
+    transport http {
+      read_timeout 5m
+      write_timeout 5m
+      dial_timeout 60s
+    }
+  }
+
+  header {
+    X-Content-Type-Options nosniff
+    Referrer-Policy strict-origin-when-cross-origin
+    Permissions-Policy "camera=(self), microphone=(self), geolocation=()"
+    -Server
+  }
+
+  tls {$ACME_EMAIL}
+}

--- a/digitalocean/Dockerfile
+++ b/digitalocean/Dockerfile
@@ -1,0 +1,17 @@
+ARG BASE_IMAGE=ruslanmv/homepilot:latest
+FROM ${BASE_IMAGE}
+
+USER root
+
+COPY notifications/content-notice.css /home/user/app/static/homepilot-content-notice.css
+COPY notifications/content-notice.js /home/user/app/static/homepilot-content-notice.js
+COPY digitalocean/inject-notifications.py /tmp/inject-notifications.py
+
+RUN python /tmp/inject-notifications.py /home/user/app/static/index.html \
+    && rm /tmp/inject-notifications.py \
+    && chown user:user \
+       /home/user/app/static/index.html \
+       /home/user/app/static/homepilot-content-notice.css \
+       /home/user/app/static/homepilot-content-notice.js
+
+USER user

--- a/digitalocean/README.md
+++ b/digitalocean/README.md
@@ -1,0 +1,96 @@
+# HomePilot on DigitalOcean
+
+This folder provides an additive deployment for a DigitalOcean Ubuntu Droplet. It does not modify the existing HomePilot frontend, backend, Docker Compose stack, or container image.
+
+The wrapper image extends the published HomePilot image and injects the neutral welcome notice plus the optional mature-mode consent dialog from `notifications/`.
+
+## Recommended Droplet
+
+- Ubuntu 24.04 LTS
+- At least 4 GB RAM
+- 50–80 GB storage
+- A domain with an A record pointing to the Droplet
+- External LLM APIs rather than a local model on a CPU-only Droplet
+
+## 1. Bootstrap the server
+
+Clone the repository or copy this directory to the Droplet, then run:
+
+```bash
+sudo bash digitalocean/install.sh
+sudo cp -R digitalocean /opt/homepilot
+sudo chown -R "$USER":"$USER" /opt/homepilot
+cd /opt/homepilot
+cp .env.example .env
+```
+
+Edit `.env`, set the domain and API credentials, and generate the application API key:
+
+```bash
+openssl rand -hex 32
+```
+
+Do not expose HomePilot with an empty `API_KEY`.
+
+## 2. Deploy
+
+```bash
+cd /opt/homepilot
+bash deploy.sh
+```
+
+Caddy obtains and renews HTTPS certificates automatically. Ports 80 and 443 must be reachable, and the domain must already resolve to the Droplet.
+
+## 3. GitHub Actions deployment
+
+The workflow `.github/workflows/digitalocean.yml` builds the additive image and publishes it as:
+
+```text
+ghcr.io/<repository-owner>/homepilot-digitalocean:<commit-sha>
+```
+
+Configure the `digitalocean-production` GitHub environment with:
+
+- `DO_HOST`: Droplet IP or hostname
+- `DO_USER`: SSH user with permission to run Docker
+- `DO_SSH_PRIVATE_KEY`: private deployment key
+- `DO_SSH_PORT`: optional; defaults to 22
+
+The server must already contain `/opt/homepilot`, `docker-compose.yml`, `Caddyfile`, `deploy.sh`, and a completed `.env`.
+
+Make the GHCR package public, or authenticate Docker on the Droplet with a read-only GitHub Packages token before deployment.
+
+The workflow runs automatically after these deployment files are changed on `master`, and it can also be started manually.
+
+## Operations
+
+View status and logs:
+
+```bash
+docker compose ps
+docker compose logs -f homepilot
+docker compose logs -f caddy
+```
+
+Back up persistent application data:
+
+```bash
+docker run --rm \
+  -v digitalocean_homepilot-data:/data:ro \
+  -v "$PWD":/backup \
+  alpine tar czf "/backup/homepilot-data-$(date +%F).tar.gz" -C /data .
+```
+
+The exact Docker volume prefix depends on the Compose project directory. Confirm it with `docker volume ls` before backing up.
+
+## Notice behavior
+
+The welcome notice explains that HomePilot is a general-purpose AI platform. It does not label the whole application as adult or pornographic.
+
+Age confirmation appears only when the application dispatches:
+
+```js
+window.dispatchEvent(new CustomEvent("homepilot:mature-mode-requested"));
+```
+
+See `notifications/README.md` for the integration API. The browser notice does not replace server-side moderation, account controls, or legally required age-assurance measures.

--- a/digitalocean/deploy.sh
+++ b/digitalocean/deploy.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$ROOT_DIR"
+
+if [[ ! -f .env ]]; then
+  echo "Missing digitalocean/.env. Copy .env.example and fill in the required values." >&2
+  exit 1
+fi
+
+set -a
+# shellcheck disable=SC1091
+source .env
+set +a
+
+: "${HOMEPILOT_DOMAIN:?HOMEPILOT_DOMAIN is required}"
+: "${ACME_EMAIL:?ACME_EMAIL is required}"
+: "${API_KEY:?API_KEY is required}"
+
+if [[ ${#API_KEY} -lt 32 || "$API_KEY" == replace-* ]]; then
+  echo "API_KEY must be a strong random value of at least 32 characters." >&2
+  exit 1
+fi
+
+docker compose pull
+docker compose up -d --remove-orphans
+docker compose ps
+
+echo "HomePilot deployment requested for https://${HOMEPILOT_DOMAIN}"

--- a/digitalocean/docker-compose.yml
+++ b/digitalocean/docker-compose.yml
@@ -1,0 +1,40 @@
+services:
+  homepilot:
+    image: ${HOMEPILOT_IMAGE:-ghcr.io/ruslanmv/homepilot-digitalocean:latest}
+    container_name: homepilot
+    restart: unless-stopped
+    env_file:
+      - .env
+    ports:
+      - "${HOMEPILOT_BIND_ADDRESS:-127.0.0.1}:7860:7860"
+    volumes:
+      - homepilot-data:/home/user/app/data
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:7860/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+
+  caddy:
+    image: caddy:2-alpine
+    container_name: homepilot-caddy
+    restart: unless-stopped
+    depends_on:
+      homepilot:
+        condition: service_healthy
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      HOMEPILOT_DOMAIN: ${HOMEPILOT_DOMAIN}
+      ACME_EMAIL: ${ACME_EMAIL}
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+
+volumes:
+  homepilot-data:
+  caddy-data:
+  caddy-config:

--- a/digitalocean/inject-notifications.py
+++ b/digitalocean/inject-notifications.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Inject HomePilot notice assets into a compiled frontend index."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+CSS_TAG = '<link rel="stylesheet" href="/homepilot-content-notice.css">'
+JS_TAG = '<script defer src="/homepilot-content-notice.js"></script>'
+
+
+def inject(index_path: Path) -> None:
+    if not index_path.is_file():
+        raise SystemExit(f"Frontend index not found: {index_path}")
+
+    content = index_path.read_text(encoding="utf-8")
+
+    if CSS_TAG not in content:
+        if "</head>" not in content:
+            raise SystemExit("Cannot inject notice CSS: </head> is missing")
+        content = content.replace("</head>", f"  {CSS_TAG}\n</head>", 1)
+
+    if JS_TAG not in content:
+        if "</body>" not in content:
+            raise SystemExit("Cannot inject notice script: </body> is missing")
+        content = content.replace("</body>", f"  {JS_TAG}\n</body>", 1)
+
+    index_path.write_text(content, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        raise SystemExit("Usage: inject-notifications.py /path/to/index.html")
+    inject(Path(sys.argv[1]))

--- a/digitalocean/install.sh
+++ b/digitalocean/install.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+if [[ ${EUID} -ne 0 ]]; then
+  echo "Run this script as root: sudo bash digitalocean/install.sh" >&2
+  exit 1
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y ca-certificates curl git ufw
+
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+  | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+chmod a+r /etc/apt/keyrings/docker.gpg
+
+. /etc/os-release
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu ${VERSION_CODENAME} stable" \
+  > /etc/apt/sources.list.d/docker.list
+
+apt-get update
+apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+systemctl enable --now docker
+
+ufw allow OpenSSH
+ufw allow 80/tcp
+ufw allow 443/tcp
+ufw --force enable
+
+install -d -m 0750 /opt/homepilot
+
+echo "Droplet bootstrap complete. Copy digitalocean/ to /opt/homepilot, create .env, then run deploy.sh."

--- a/notifications/README.md
+++ b/notifications/README.md
@@ -1,0 +1,43 @@
+# HomePilot content notices
+
+This folder contains an additive, framework-independent notice layer for hosted HomePilot deployments.
+
+It presents HomePilot as a general-purpose AI platform for work, productivity, creativity, assistance, and companionship. Mature settings remain optional and separate from the standard SFW experience.
+
+## Included notices
+
+- A neutral first-visit welcome notice.
+- An explicit adult-confirmation dialog that appears only when mature mode is requested.
+- Accessible keyboard focus handling and responsive styling.
+- Browser-local consent storage. No personal information is transmitted.
+
+## Integration
+
+The DigitalOcean wrapper image copies these assets into the compiled HomePilot frontend and injects the required `<link>` and `<script>` tags into `index.html`. Existing frontend source files are not changed.
+
+To request consent from an existing mature-mode control:
+
+```js
+window.dispatchEvent(new CustomEvent("homepilot:mature-mode-requested"));
+
+window.addEventListener("homepilot:mature-mode-consent", (event) => {
+  if (event.detail.accepted) {
+    // Enable the optional mature setting.
+  }
+});
+```
+
+The same behavior can be called directly:
+
+```js
+const accepted = await window.HomePilotNotifications.openMatureConsent();
+```
+
+Check or revoke consent with:
+
+```js
+window.HomePilotNotifications.hasMatureConsent();
+window.HomePilotNotifications.clearMatureConsent();
+```
+
+The notice is a user-interface safeguard, not a substitute for server-side policy enforcement, content moderation, or legally required age-assurance controls.

--- a/notifications/content-notice.css
+++ b/notifications/content-notice.css
@@ -1,0 +1,132 @@
+:root {
+  --hp-notice-bg: #ffffff;
+  --hp-notice-text: #172033;
+  --hp-notice-muted: #5f6b7a;
+  --hp-notice-border: #dfe5ec;
+  --hp-notice-accent: #4f46e5;
+  --hp-notice-accent-hover: #4338ca;
+  --hp-notice-shadow: 0 24px 80px rgba(15, 23, 42, 0.24);
+}
+
+.hp-notice-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 2147483646;
+  display: grid;
+  place-items: center;
+  padding: 20px;
+  background: rgba(15, 23, 42, 0.58);
+  backdrop-filter: blur(6px);
+}
+
+.hp-notice-dialog {
+  width: min(560px, 100%);
+  max-height: min(720px, calc(100vh - 40px));
+  overflow: auto;
+  border: 1px solid var(--hp-notice-border);
+  border-radius: 18px;
+  background: var(--hp-notice-bg);
+  color: var(--hp-notice-text);
+  box-shadow: var(--hp-notice-shadow);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.hp-notice-body {
+  padding: 28px;
+}
+
+.hp-notice-eyebrow {
+  margin: 0 0 8px;
+  color: var(--hp-notice-accent);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.hp-notice-title {
+  margin: 0;
+  font-size: clamp(1.45rem, 4vw, 2rem);
+  line-height: 1.15;
+}
+
+.hp-notice-copy {
+  margin: 16px 0 0;
+  color: var(--hp-notice-muted);
+  font-size: 1rem;
+  line-height: 1.65;
+}
+
+.hp-notice-list {
+  margin: 16px 0 0;
+  padding-left: 22px;
+  color: var(--hp-notice-muted);
+  line-height: 1.6;
+}
+
+.hp-notice-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 18px 28px;
+  border-top: 1px solid var(--hp-notice-border);
+  background: #f8fafc;
+  border-radius: 0 0 18px 18px;
+}
+
+.hp-notice-button {
+  min-height: 44px;
+  padding: 10px 18px;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 700;
+}
+
+.hp-notice-button:focus-visible {
+  outline: 3px solid rgba(79, 70, 229, 0.28);
+  outline-offset: 2px;
+}
+
+.hp-notice-button--primary {
+  background: var(--hp-notice-accent);
+  color: #ffffff;
+}
+
+.hp-notice-button--primary:hover {
+  background: var(--hp-notice-accent-hover);
+}
+
+.hp-notice-button--secondary {
+  border-color: var(--hp-notice-border);
+  background: #ffffff;
+  color: var(--hp-notice-text);
+}
+
+.hp-notice-fine-print {
+  margin: 14px 0 0;
+  color: var(--hp-notice-muted);
+  font-size: 0.82rem;
+  line-height: 1.5;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --hp-notice-bg: #111827;
+    --hp-notice-text: #f8fafc;
+    --hp-notice-muted: #cbd5e1;
+    --hp-notice-border: #334155;
+    --hp-notice-shadow: 0 24px 80px rgba(0, 0, 0, 0.5);
+  }
+
+  .hp-notice-actions {
+    background: #0f172a;
+  }
+
+  .hp-notice-button--secondary {
+    background: #1e293b;
+    color: #f8fafc;
+  }
+}

--- a/notifications/content-notice.js
+++ b/notifications/content-notice.js
@@ -1,0 +1,227 @@
+(() => {
+  "use strict";
+
+  const WELCOME_KEY = "homepilot.notice.welcome.v1";
+  const MATURE_KEY = "homepilot.notice.mature-consent.v1";
+  const config = Object.assign(
+    {
+      showWelcome: true,
+      welcomeDelayMs: 250,
+    },
+    window.HomePilotNoticeConfig || {},
+  );
+
+  let activeModal = null;
+  let previousFocus = null;
+
+  function closeModal(result) {
+    if (!activeModal) return;
+    const { backdrop, resolve } = activeModal;
+    activeModal = null;
+    backdrop.remove();
+    document.body.style.removeProperty("overflow");
+    if (previousFocus && typeof previousFocus.focus === "function") {
+      previousFocus.focus();
+    }
+    previousFocus = null;
+    if (resolve) resolve(result);
+  }
+
+  function createModal({ eyebrow, title, copy, list = [], finePrint, actions }) {
+    if (activeModal) closeModal(false);
+
+    previousFocus = document.activeElement;
+    const backdrop = document.createElement("div");
+    backdrop.className = "hp-notice-backdrop";
+
+    const dialog = document.createElement("section");
+    dialog.className = "hp-notice-dialog";
+    dialog.setAttribute("role", "dialog");
+    dialog.setAttribute("aria-modal", "true");
+    dialog.setAttribute("aria-labelledby", "hp-notice-title");
+
+    const body = document.createElement("div");
+    body.className = "hp-notice-body";
+
+    if (eyebrow) {
+      const eyebrowNode = document.createElement("p");
+      eyebrowNode.className = "hp-notice-eyebrow";
+      eyebrowNode.textContent = eyebrow;
+      body.appendChild(eyebrowNode);
+    }
+
+    const titleNode = document.createElement("h2");
+    titleNode.id = "hp-notice-title";
+    titleNode.className = "hp-notice-title";
+    titleNode.textContent = title;
+    body.appendChild(titleNode);
+
+    copy.forEach((paragraph) => {
+      const node = document.createElement("p");
+      node.className = "hp-notice-copy";
+      node.textContent = paragraph;
+      body.appendChild(node);
+    });
+
+    if (list.length) {
+      const listNode = document.createElement("ul");
+      listNode.className = "hp-notice-list";
+      list.forEach((item) => {
+        const itemNode = document.createElement("li");
+        itemNode.textContent = item;
+        listNode.appendChild(itemNode);
+      });
+      body.appendChild(listNode);
+    }
+
+    if (finePrint) {
+      const finePrintNode = document.createElement("p");
+      finePrintNode.className = "hp-notice-fine-print";
+      finePrintNode.textContent = finePrint;
+      body.appendChild(finePrintNode);
+    }
+
+    const actionsNode = document.createElement("div");
+    actionsNode.className = "hp-notice-actions";
+
+    actions.forEach((action) => {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = `hp-notice-button hp-notice-button--${action.kind || "secondary"}`;
+      button.textContent = action.label;
+      button.addEventListener("click", action.onClick);
+      actionsNode.appendChild(button);
+    });
+
+    dialog.append(body, actionsNode);
+    backdrop.appendChild(dialog);
+    document.body.appendChild(backdrop);
+    document.body.style.overflow = "hidden";
+
+    const firstButton = actionsNode.querySelector("button");
+    if (firstButton) firstButton.focus();
+
+    backdrop.addEventListener("keydown", (event) => {
+      if (event.key === "Escape") closeModal(false);
+      if (event.key !== "Tab") return;
+
+      const focusable = Array.from(dialog.querySelectorAll("button"));
+      if (!focusable.length) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    });
+
+    return backdrop;
+  }
+
+  function openWelcome(force = false) {
+    if (!force && localStorage.getItem(WELCOME_KEY) === "accepted") return;
+
+    const backdrop = createModal({
+      eyebrow: "General-purpose AI",
+      title: "Welcome to HomePilot",
+      copy: [
+        "HomePilot supports work, productivity, creativity, assistance, and personalized AI companionship.",
+        "Most features are suitable for everyday and professional use. Optional mature settings, where available, are separate from the standard experience and require adult confirmation.",
+      ],
+      finePrint:
+        "Illegal, exploitative, non-consensual, or underage sexual content is strictly prohibited.",
+      actions: [
+        {
+          label: "Continue",
+          kind: "primary",
+          onClick: () => {
+            localStorage.setItem(WELCOME_KEY, "accepted");
+            closeModal(true);
+          },
+        },
+      ],
+    });
+
+    activeModal = { backdrop, resolve: null };
+  }
+
+  function openMatureConsent() {
+    return new Promise((resolve) => {
+      const backdrop = createModal({
+        eyebrow: "Optional setting · Adults only",
+        title: "Enable Mature Content Mode?",
+        copy: [
+          "HomePilot is primarily a general-purpose AI assistant and companionship platform. This optional mode is separate from the standard SFW workspace.",
+          "Mature settings may allow adult-oriented conversations or non-explicit romantic and suggestive content. They are not required to use HomePilot.",
+        ],
+        list: [
+          "I confirm that I am at least 18 years old.",
+          "I understand that mature themes may appear.",
+          "I will not create illegal, exploitative, non-consensual, or underage content.",
+        ],
+        finePrint: "Mature Content Mode can be disabled at any time in Settings.",
+        actions: [
+          {
+            label: "Cancel",
+            kind: "secondary",
+            onClick: () => closeModal(false),
+          },
+          {
+            label: "I’m 18+ and Enable",
+            kind: "primary",
+            onClick: () => {
+              localStorage.setItem(
+                MATURE_KEY,
+                JSON.stringify({ accepted: true, acceptedAt: new Date().toISOString() }),
+              );
+              closeModal(true);
+            },
+          },
+        ],
+      });
+
+      activeModal = { backdrop, resolve };
+    });
+  }
+
+  function hasMatureConsent() {
+    try {
+      const value = JSON.parse(localStorage.getItem(MATURE_KEY) || "null");
+      return Boolean(value && value.accepted === true);
+    } catch (_) {
+      return false;
+    }
+  }
+
+  function clearMatureConsent() {
+    localStorage.removeItem(MATURE_KEY);
+  }
+
+  window.HomePilotNotifications = Object.freeze({
+    openWelcome,
+    openMatureConsent,
+    hasMatureConsent,
+    clearMatureConsent,
+  });
+
+  window.addEventListener("homepilot:mature-mode-requested", async () => {
+    const accepted = hasMatureConsent() || (await openMatureConsent());
+    window.dispatchEvent(
+      new CustomEvent("homepilot:mature-mode-consent", { detail: { accepted } }),
+    );
+  });
+
+  function start() {
+    if (!config.showWelcome) return;
+    window.setTimeout(() => openWelcome(false), Number(config.welcomeDelayMs) || 0);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", start, { once: true });
+  } else {
+    start();
+  }
+})();


### PR DESCRIPTION
## What changed

- Added an isolated `digitalocean/` deployment package for Ubuntu Droplets.
- Added a wrapper Docker image that extends the existing HomePilot image instead of modifying it.
- Added persistent Docker Compose deployment with Caddy-managed HTTPS.
- Added server bootstrap and idempotent deployment scripts.
- Added a GitHub Actions workflow that publishes the wrapper image to GHCR and deploys it over SSH.
- Added a standalone `notifications/` module with a neutral general-purpose welcome notice and adult confirmation only when mature mode is requested.
- Added documentation for setup, GitHub secrets, operations, backups, and integration.

## Why

HomePilot supports ordinary SFW work, productivity, creativity, assistance, and companionship. The hosted deployment should not imply that the entire product is pornographic. Mature settings are therefore optional, separated from the normal experience, and gated only when requested.

## Safety and compatibility

- All files are additive.
- No existing frontend, backend, container, or workflow files are changed.
- An application `API_KEY` of at least 32 characters is required by the deployment script.
- HomePilot binds to loopback and is exposed through Caddy over HTTPS.
- Persistent application data is stored in a named Docker volume.

## Validation

- Confirmed the branch is based directly on `master` and changes only 12 new files.
- Confirmed the notification injector is idempotent and fails when required HTML anchors are absent.
- Confirmed the Compose health check uses HomePilot's existing `/api/health` endpoint.

A live image build and Droplet deployment still require the configured GitHub environment and DigitalOcean server.