### PR TITLE
Optimize Oracle deploy for small ARM Always Free shape

### DIFF
--- a/oracle/README.md
+++ b/oracle/README.md
@@ -23,7 +23,9 @@ Free eligible shape:
 
 Other Always Free details:
 
-- **Image:** Canonical **Ubuntu 24.04**.
+- **Image:** **Oracle Linux 9** (default on the A1 shape, SSH user `opc`) or
+  **Ubuntu** (SSH user `ubuntu`). `install.sh` detects the OS and configures
+  Docker + the host firewall for either — no manual edits needed.
 - **Boot/block storage:** stays within the 200 GB Always Free block volume total.
 - **Public IP:** assign one (reserve it if you want it to survive instance
   recreation), and create a DNS **A record** pointing your domain at it.
@@ -42,7 +44,8 @@ OCI blocks inbound traffic in **two** places — both must allow TCP 80 and 443:
    Security List, and add **Ingress** rules:
    - Source `0.0.0.0/0`, IP protocol TCP, destination port **80**
    - Source `0.0.0.0/0`, IP protocol TCP, destination port **443**
-2. **Host firewall (iptables):** handled by `install.sh` below.
+2. **Host firewall:** handled by `install.sh` below — `firewalld` on Oracle
+   Linux, `iptables` on Ubuntu.
 
 ## 2. Bootstrap the instance
 
@@ -51,13 +54,23 @@ Clone the repository or copy this directory to the instance, then run:
 ```bash
 sudo bash oracle/install.sh
 sudo cp -R oracle /opt/homepilot
-sudo chown -R "$USER":"$USER" /opt/homepilot
 cd /opt/homepilot
 cp .env.example .env
 ```
 
-`install.sh` installs Docker, opens ports 80/443 in the host iptables (Oracle's
-Ubuntu images ship a default REJECT rule), and persists them across reboots.
+`install.sh` is OS-aware. It:
+
+- installs Docker (dnf on Oracle Linux, apt on Ubuntu);
+- opens ports 80/443 (firewalld on Oracle Linux, iptables on Ubuntu) and
+  persists them across reboots;
+- creates a **4 GB swap file** so pulls/spikes don't OOM-kill the app on the
+  small shapes (override with `SWAP_SIZE=2G`, or `SWAP_SIZE=0` to skip);
+- adds the deploy user (the account that ran `sudo`, e.g. `opc`) to the
+  `docker` group and gives it `/opt/homepilot`, so no `chown`/`sudo` is needed.
+
+> After `install.sh` adds you to the `docker` group, **open a new SSH session**
+> before running `deploy.sh` so the group membership takes effect. (GitHub
+> Actions reconnects on every run, so it is unaffected.)
 
 Edit `.env`, set the domain and API credentials, and generate the application
 API key:
@@ -67,14 +80,6 @@ openssl rand -hex 32
 ```
 
 Do not expose HomePilot with an empty `API_KEY`.
-
-> On the 1 GB `E2.1.Micro` shape, add a swap file first so builds/pulls don't
-> get OOM-killed:
-> ```bash
-> sudo fallocate -l 2G /swapfile && sudo chmod 600 /swapfile
-> sudo mkswap /swapfile && sudo swapon /swapfile
-> echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
-> ```
 
 ## 3. Deploy
 
@@ -99,9 +104,11 @@ ghcr.io/<repository-owner>/homepilot-oracle:<commit-sha>
 
 Configure the `oracle-production` GitHub environment with:
 
-- `ORACLE_HOST`: instance public IP or hostname
-- `ORACLE_USER`: SSH user with permission to run Docker (e.g. `ubuntu`)
-- `ORACLE_SSH_PRIVATE_KEY`: private deployment key
+- `ORACLE_HOST`: instance public IP or hostname (e.g. `193.122.156.100`)
+- `ORACLE_USER`: SSH user with permission to run Docker — `opc` on Oracle
+  Linux, `ubuntu` on Ubuntu (added to the `docker` group by `install.sh`)
+- `ORACLE_SSH_PRIVATE_KEY`: private deployment key (full PEM, matching a public
+  key in the instance's `~/.ssh/authorized_keys`)
 - `ORACLE_SSH_PORT`: optional; defaults to 22
 
 The server must already contain `/opt/homepilot`, `docker-compose.yml`,
@@ -171,6 +178,20 @@ docker run --rm \
 
 The exact Docker volume prefix depends on the Compose project directory. Confirm
 it with `docker volume ls` before backing up.
+
+### Resource limits
+
+`docker-compose.yml` caps the app at **5 GB RAM** (`mem_limit`) with a 7 GB
+RAM+swap ceiling (`memswap_limit`) and Caddy at **256 MB**, sized for the
+1 OCPU / 6 GB `A1.Flex`. Container logs are rotated (3 × 10 MB) so they can't
+fill the boot volume. On a larger shape, raise them in `.env` without editing
+the compose file:
+
+```bash
+HOMEPILOT_MEM_LIMIT=20g
+HOMEPILOT_MEMSWAP_LIMIT=24g
+CADDY_MEM_LIMIT=512m
+```
 
 ## Notice behavior
 

--- a/oracle/deploy.sh
+++ b/oracle/deploy.sh
@@ -27,4 +27,9 @@ docker compose pull
 docker compose up -d --remove-orphans
 docker compose ps
 
+# Reclaim disk on the small Always Free boot volume: drop the now-dangling
+# image layers left behind by the pull above. Safe — only untagged images that
+# nothing references are removed; the running :sha/:latest images are kept.
+docker image prune -f >/dev/null 2>&1 || true
+
 echo "HomePilot deployment requested for https://${HOMEPILOT_DOMAIN}"

--- a/oracle/docker-compose.yml
+++ b/oracle/docker-compose.yml
@@ -9,12 +9,23 @@ services:
       - "${HOMEPILOT_BIND_ADDRESS:-127.0.0.1}:7860:7860"
     volumes:
       - homepilot-data:/home/user/app/data
+    # Tuned for VM.Standard.A1.Flex 1 OCPU / 6 GB. Leave ~1 GB for the OS and
+    # Caddy; the swap file created by install.sh absorbs short spikes above the
+    # RAM limit instead of the kernel OOM-killing the app. Override with
+    # HOMEPILOT_MEM_LIMIT / HOMEPILOT_MEMSWAP_LIMIT for larger shapes.
+    mem_limit: ${HOMEPILOT_MEM_LIMIT:-5g}
+    memswap_limit: ${HOMEPILOT_MEMSWAP_LIMIT:-7g}
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:7860/api/health"]
       interval: 30s
       timeout: 10s
       retries: 5
       start_period: 60s
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   caddy:
     image: caddy:2-alpine
@@ -33,6 +44,12 @@ services:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy-data:/data
       - caddy-config:/config
+    mem_limit: ${CADDY_MEM_LIMIT:-256m}
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
 volumes:
   homepilot-data:

--- a/oracle/install.sh
+++ b/oracle/install.sh
@@ -1,53 +1,147 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-# Bootstraps an Oracle Cloud Infrastructure "Always Free" compute instance
-# (Ubuntu) for the HomePilot web deployment. Works on both Always Free shapes:
-#   - VM.Standard.A1.Flex    (Ampere ARM / aarch64, up to 4 OCPU / 24 GB)
-#   - VM.Standard.E2.1.Micro (AMD x86_64, 1 GB)
+# Bootstraps an Oracle Cloud Infrastructure "Always Free" compute instance for
+# the HomePilot web deployment. OS-aware — supports both Always Free families:
+#   - Oracle Linux 8/9  (dnf + firewalld)  e.g. VM.Standard.A1.Flex, user "opc"
+#   - Ubuntu            (apt + iptables)   e.g. VM.Standard.E2.1.Micro, user "ubuntu"
 #
-# Note: opening ports here is only half the job. You must ALSO add ingress
-# rules for TCP 80 and 443 to the instance subnet's Security List (or Network
-# Security Group) in the OCI console. See oracle/README.md.
+# Tuned for the small Always Free shapes (as little as 1 OCPU / 1–6 GB RAM):
+# creates a swap file and applies conservative VM tuning so a memory spike from
+# an image pull or a request burst doesn't OOM-kill the container.
+#
+# Opening ports here is only half the job — you must ALSO add ingress rules for
+# TCP 80 and 443 to the subnet's Security List / NSG in the OCI console.
+# See oracle/README.md.
+#
+# Tunables (override via environment):
+#   DEPLOY_USER  account that owns /opt/homepilot and runs docker (default: sudo user)
+#   SWAP_SIZE    swap file size, e.g. 2G / 4G (default: 4G; set to 0 to skip)
 
 if [[ ${EUID} -ne 0 ]]; then
   echo "Run this script as root: sudo bash oracle/install.sh" >&2
   exit 1
 fi
 
-export DEBIAN_FRONTEND=noninteractive
-apt-get update
-apt-get install -y ca-certificates curl git iptables-persistent
+# The unprivileged account that will own /opt/homepilot and run docker compose.
+# Defaults to whoever invoked sudo (opc on Oracle Linux, ubuntu on Ubuntu).
+DEPLOY_USER="${DEPLOY_USER:-${SUDO_USER:-}}"
+SWAP_SIZE="${SWAP_SIZE:-4G}"
 
-install -m 0755 -d /etc/apt/keyrings
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
-  | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-chmod a+r /etc/apt/keyrings/docker.gpg
-
+# shellcheck disable=SC1091
 . /etc/os-release
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu ${VERSION_CODENAME} stable" \
-  > /etc/apt/sources.list.d/docker.list
+OS_ID="${ID:-}"
+OS_LIKE="${ID_LIKE:-}"
 
-apt-get update
-apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-systemctl enable --now docker
+# ---------------------------------------------------------------------------
+# Docker installation (OS-aware)
+# ---------------------------------------------------------------------------
+install_docker_rhel() {
+  dnf -y install git curl ca-certificates dnf-plugins-core
+  # dnf-3 uses `config-manager --add-repo`; newer dnf5 uses `addrepo`.
+  dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo 2>/dev/null \
+    || dnf config-manager addrepo --from-repofile=https://download.docker.com/linux/centos/docker-ce.repo
+  dnf -y install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+  systemctl enable --now docker
+}
 
-# Oracle's Ubuntu images ship a default INPUT policy that REJECTs inbound
-# traffic (via a rule near the end of the chain). Insert ACCEPT rules for HTTP
-# and HTTPS ahead of that reject rule so Caddy can serve traffic and complete
-# the ACME challenge, then persist them across reboots.
-open_port() {
-  local port="$1"
-  if ! iptables -C INPUT -p tcp --dport "$port" -m conntrack --ctstate NEW -j ACCEPT 2>/dev/null; then
-    iptables -I INPUT 5 -p tcp --dport "$port" -m conntrack --ctstate NEW -j ACCEPT
+install_docker_debian() {
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get update
+  apt-get install -y ca-certificates curl git iptables-persistent
+  install -m 0755 -d /etc/apt/keyrings
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+    | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+  chmod a+r /etc/apt/keyrings/docker.gpg
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu ${VERSION_CODENAME} stable" \
+    > /etc/apt/sources.list.d/docker.list
+  apt-get update
+  apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+  systemctl enable --now docker
+}
+
+# ---------------------------------------------------------------------------
+# Host firewall — open 80/443 (OS-aware)
+# ---------------------------------------------------------------------------
+open_ports_firewalld() {
+  firewall-cmd --permanent --add-service=http
+  firewall-cmd --permanent --add-service=https
+  firewall-cmd --reload
+}
+
+open_ports_iptables() {
+  # Oracle's images ship a default INPUT policy that REJECTs inbound traffic via
+  # a rule near the end of the chain. Insert ACCEPT rules for HTTP/HTTPS ahead
+  # of that reject rule, then persist across reboots.
+  open_port() {
+    local port="$1"
+    if ! iptables -C INPUT -p tcp --dport "$port" -m conntrack --ctstate NEW -j ACCEPT 2>/dev/null; then
+      iptables -I INPUT 5 -p tcp --dport "$port" -m conntrack --ctstate NEW -j ACCEPT
+    fi
+  }
+  open_port 80
+  open_port 443
+  if command -v netfilter-persistent >/dev/null 2>&1; then
+    netfilter-persistent save
+  elif command -v service >/dev/null 2>&1 && [[ -d /etc/iptables ]]; then
+    iptables-save > /etc/iptables/rules.v4 || true
   fi
 }
-open_port 80
-open_port 443
-netfilter-persistent save
 
-install -d -m 0750 /opt/homepilot
+if command -v dnf >/dev/null 2>&1 || [[ "$OS_ID" == "ol" || "$OS_LIKE" == *rhel* || "$OS_LIKE" == *fedora* ]]; then
+  echo "Detected RHEL family (${PRETTY_NAME:-$OS_ID}); using dnf + firewalld."
+  install_docker_rhel
+  if command -v firewall-cmd >/dev/null 2>&1 && systemctl is-active --quiet firewalld; then
+    open_ports_firewalld
+  else
+    open_ports_iptables
+  fi
+else
+  echo "Detected Debian family (${PRETTY_NAME:-$OS_ID}); using apt + iptables."
+  install_docker_debian
+  open_ports_iptables
+fi
 
+# ---------------------------------------------------------------------------
+# Swap — critical on the small Always Free shapes (1–6 GB RAM)
+# ---------------------------------------------------------------------------
+if [[ "$SWAP_SIZE" != "0" ]] && ! swapon --show=NAME --noheadings | grep -q '/swapfile'; then
+  echo "Creating ${SWAP_SIZE} swap file at /swapfile..."
+  if ! fallocate -l "$SWAP_SIZE" /swapfile 2>/dev/null; then
+    # fallocate can fail on some filesystems — fall back to dd (GiB granularity)
+    dd if=/dev/zero of=/swapfile bs=1M count=$(( ${SWAP_SIZE%G} * 1024 )) status=none
+  fi
+  chmod 600 /swapfile
+  mkswap /swapfile >/dev/null
+  swapon /swapfile
+  grep -q '^/swapfile ' /etc/fstab || echo '/swapfile none swap sw 0 0' >> /etc/fstab
+fi
+
+# ---------------------------------------------------------------------------
+# VM tuning for low-memory hosts — prefer RAM, but let swap absorb spikes.
+# ---------------------------------------------------------------------------
+cat > /etc/sysctl.d/99-homepilot.conf <<'SYSCTL'
+vm.swappiness = 10
+vm.vfs_cache_pressure = 50
+vm.overcommit_memory = 1
+SYSCTL
+sysctl --quiet -p /etc/sysctl.d/99-homepilot.conf || true
+
+# ---------------------------------------------------------------------------
+# Deploy user: run docker without sudo + own the app directory
+# ---------------------------------------------------------------------------
+install -d -m 0755 /opt/homepilot
+if [[ -n "$DEPLOY_USER" ]] && id "$DEPLOY_USER" >/dev/null 2>&1; then
+  usermod -aG docker "$DEPLOY_USER"
+  chown -R "$DEPLOY_USER":"$DEPLOY_USER" /opt/homepilot
+  echo "Added '$DEPLOY_USER' to the docker group and gave it /opt/homepilot."
+  echo "NOTE: '$DEPLOY_USER' must open a NEW SSH session for docker-group"
+  echo "      membership to take effect (GitHub Actions reconnects each run)."
+fi
+
+echo
 echo "Instance bootstrap complete."
-echo "Next: add ingress rules for TCP 80 and 443 in the OCI Security List,"
-echo "copy oracle/ to /opt/homepilot, create .env, then run deploy.sh."
+echo "Next steps:"
+echo "  1. Add ingress rules for TCP 80 and 443 in the OCI Security List / NSG."
+echo "  2. Copy oracle/ into /opt/homepilot, create .env from .env.example."
+echo "  3. Run: cd /opt/homepilot && bash deploy.sh"


### PR DESCRIPTION
The bootstrap scripts assumed Ubuntu (apt/iptables), but the recommended
A1.Flex Always Free instance runs Oracle Linux 9 (aarch64, user opc,
dnf/firewalld) — install.sh would fail outright there. Also tune the
stack for the 1 OCPU / 6 GB shape so it doesn't OOM or fill the small
boot volume.

install.sh:
- Detect OS: dnf + firewalld on Oracle Linux / RHEL family, apt +
  iptables on Ubuntu/Debian. Install Docker CE from the matching repo.
- Create a swap file (default 4G, SWAP_SIZE override) so image pulls and
  request spikes don't OOM-kill the container on low-RAM shapes.
- Apply low-memory VM tuning (swappiness, overcommit, cache pressure).
- Add the deploy user (opc/ubuntu) to the docker group and give it
  /opt/homepilot, so deploy needs no sudo/chown.

docker-compose.yml:
- Cap homepilot at 5g RAM / 7g RAM+swap and caddy at 256m (overridable
  via HOMEPILOT_MEM_LIMIT / HOMEPILOT_MEMSWAP_LIMIT / CADDY_MEM_LIMIT)
  so a spike can't take down the 6 GB host.
- Rotate container logs (3 x 10m) to protect the boot volume.

deploy.sh:
- Prune dangling image layers after each deploy to reclaim disk.

README: document Oracle Linux 9 / opc, the automatic swap + docker-group
setup, the resource-limit tunables, and the concrete ORACLE_* secrets.