### PR TITLE
Disable ComfyUI in the Oracle image (CPU-only, low RAM)

### DIFF
--- a/oracle/Dockerfile
+++ b/oracle/Dockerfile
@@ -17,4 +17,19 @@ RUN python /tmp/inject-notifications.py /home/user/app/static/index.html \
        /home/user/app/static/homepilot-content-notice.css \
        /home/user/app/static/homepilot-content-notice.js
 
+# Oracle's Always Free shapes are CPU-only with little RAM, and this deployment
+# targets an external LLM API — the bundled ComfyUI diffusion engine can't do
+# useful work here and its CPU-torch startup saturates the single OCPU and risks
+# OOM-killing the backend, which then never becomes healthy. Disable ComfyUI's
+# autostart so only nginx + the backend run. (Guarded so the build still
+# succeeds if the base image ever relocates the supervisord config.)
+RUN SV=/etc/supervisor/conf.d/supervisord.conf; \
+    if [ -f "$SV" ]; then \
+      awk '/^\[program:comfyui\]/{b=1} /^\[program:/ && $0 !~ /comfyui/{b=0} b && /^autostart=/{print "autostart=false"; next} {print}' "$SV" > "$SV.tmp" \
+      && mv "$SV.tmp" "$SV" \
+      && echo "ComfyUI autostart disabled for the Oracle image."; \
+    else \
+      echo "supervisord.conf not found at $SV — leaving base image untouched."; \
+    fi
+
 USER user


### PR DESCRIPTION
The container stays unhealthy for 5+ minutes on the 1 OCPU / 6 GB Ampere
shape. Beyond the healthcheck path fix, the bundled ComfyUI diffusion
engine autostarts and loads CPU-torch + custom nodes, saturating the
single core and risking an OOM under the 5 GB limit — starving the
backend so it can't answer /health in time. ComfyUI can't do useful work
on this GPU-less box anyway (this deployment uses an external LLM API).

Patch the supervisord config in the Oracle wrapper image to set the
ComfyUI program's autostart=false, so only nginx and the backend run.
The awk edit is scoped to the [program:comfyui] block and guarded so the
build still succeeds if the base image relocates the config.
