### PR TITLE
Cut Oracle backend to 1 worker and widen health grace

### DIFF
--- a/oracle/Dockerfile
+++ b/oracle/Dockerfile
@@ -27,7 +27,8 @@ RUN SV=/etc/supervisor/conf.d/supervisord.conf; \
     if [ -f "$SV" ]; then \
       awk '/^\[program:comfyui\]/{b=1} /^\[program:/ && $0 !~ /comfyui/{b=0} b && /^autostart=/{print "autostart=false"; next} {print}' "$SV" > "$SV.tmp" \
       && mv "$SV.tmp" "$SV" \
-      && echo "ComfyUI autostart disabled for the Oracle image."; \
+      && sed -i 's/--workers[[:space:]]\+[0-9]\+/--workers 1/' "$SV" \
+      && echo "Oracle image: ComfyUI autostart disabled; backend workers=1."; \
     else \
       echo "supervisord.conf not found at $SV — leaving base image untouched."; \
     fi

--- a/oracle/docker-compose.yml
+++ b/oracle/docker-compose.yml
@@ -21,12 +21,18 @@ services:
     # 404'd and the container never became healthy. Hitting :8000/health inside
     # the container avoids that mapping. start_period is generous because the
     # app is slow to import on the 1 OCPU Ampere shape.
+    # start_period is generous — during it, failing probes do NOT count as
+    # failures or toward "unhealthy", they just keep the container "starting".
+    # The app is slow to import on a single Ampere core. Total grace before
+    # "unhealthy" is start_period + retries*interval = 240 + 12*15 = 420s,
+    # comfortably under the deploy SSH step's 10m command timeout so a truly
+    # broken app still fails cleanly instead of hanging.
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:8000/health"]
       interval: 15s
       timeout: 10s
-      retries: 10
-      start_period: 180s
+      retries: 12
+      start_period: 240s
     logging:
       driver: json-file
       options:


### PR DESCRIPTION
Even with the /8000 healthcheck and ComfyUI disabled, the container went
unhealthy at ~5.5m — the backend never answered /health in time. The
image runs uvicorn with 2 workers, each loading the full app + ML deps,
which doubles memory and startup cost on a single Ampere core (6 GB) and
risks OOM under the 5 GB limit.

- Patch supervisord in the Oracle image to run the backend with
  --workers 1 (roughly halves startup memory/CPU).
- Widen the healthcheck grace to start_period 240s + retries 12 (~420s),
  still under the deploy SSH step's 10m timeout so a genuinely broken app
  fails cleanly instead of hanging.