### PR TITLE
Add read-only SSE logs API (HF Spaces–style)

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -2,7 +2,9 @@ name: "\U0001F4E6 Publish Container (GHCR)"
 
 on:
   push:
-    branches: [main]
+    # This repo's default branch is `master` (there is no `main`), so the base
+    # image was never rebuilt and deployments served a stale frontend/backend.
+    branches: [master, main]
     paths:
       - "container/**"
       - "backend/**"

--- a/API.md
+++ b/API.md
@@ -192,3 +192,44 @@
 | `/civitai/search` | POST | Search Civitai model registry |
 | `/models/install` | POST | Install model from Civitai |
 | `/models/delete` | POST | Remove installed model |
+
+---
+
+## Logs API (Hugging Face Spaces–style, SSE)
+
+Read-only, additive log streaming for remote debugging — mirrors HF Spaces'
+`/api/spaces/<owner>/<repo>/logs/{run,build}`. Streams the container's
+supervisor logs over Server-Sent Events. **Never writes or mutates anything.**
+
+**Auth:** shared `API_KEY` (via `Authorization: Bearer <key>` or `X-API-Key`),
+a logged-in HomePilot session (JWT / `homepilot_session` cookie), or a
+same-machine request. Fail-closed for anonymous remote callers.
+
+| Endpoint | Method | Description |
+| :--- | :--- | :--- |
+| `/api/spaces/{owner}/{repo}/logs` | GET | List available log streams + sizes |
+| `/api/spaces/{owner}/{repo}/logs/{stream}` | GET | Stream a log over SSE |
+
+**Streams:** `run` (live app logs), `build` (container boot/supervisord),
+`backend`, `backend-stdout`, `nginx`, `comfyui`, `supervisord`.
+
+**Query params:** `tail` (initial lines, default 200), `follow` (`tail -f`,
+default `true`), `format` (`json` HF-style default, or `raw`), `token`
+(alternative to the header — handy for browser `EventSource`).
+
+```bash
+# live application (run) logs
+curl -N -H "Authorization: Bearer $HP_TOKEN" \
+  "https://homepilot.ruslanmv.com/api/spaces/ruslanmv/HomePilot/logs/run"
+
+# container boot (build) logs
+curl -N -H "Authorization: Bearer $HP_TOKEN" \
+  "https://homepilot.ruslanmv.com/api/spaces/ruslanmv/HomePilot/logs/build"
+
+# just the last 500 lines, no follow, plain text
+curl -H "Authorization: Bearer $HP_TOKEN" \
+  "https://homepilot.ruslanmv.com/api/spaces/ruslanmv/HomePilot/logs/run?follow=false&tail=500&format=raw"
+```
+
+The log directory is `HOMEPILOT_LOG_DIR` (default `/var/log/supervisor`), so
+desktop/self-hosted installs can point it at their own log path.

--- a/backend/app/logs_api.py
+++ b/backend/app/logs_api.py
@@ -1,0 +1,306 @@
+"""
+Container log streaming API — Hugging Face Spaces style (ADDITIVE, READ-ONLY).
+
+Lets an operator query a running HomePilot deployment's logs over SSE without
+SSH, mirroring HF Spaces' ``/api/spaces/<owner>/<repo>/logs/{run,build}``:
+
+    # live application ("run") logs
+    curl -N -H "Authorization: Bearer $HP_TOKEN" \\
+      https://homepilot.ruslanmv.com/api/spaces/ruslanmv/HomePilot/logs/run
+
+    # container boot ("build") logs
+    curl -N -H "Authorization: Bearer $HP_TOKEN" \\
+      https://homepilot.ruslanmv.com/api/spaces/ruslanmv/HomePilot/logs/build
+
+Design notes
+------------
+* ADDITIVE ONLY: a new APIRouter mounted with one ``include_router`` line.
+  It never writes, deletes, or mutates anything — it only *reads* the
+  supervisor log files the container already produces.
+* Works on both the **web** (container) and **normal/desktop** deployments:
+  the log directory is ``HOMEPILOT_LOG_DIR`` (default ``/var/log/supervisor``),
+  so a desktop install can point it at its own log path.
+* Auth reuses the shared ``API_KEY`` (Bearer or ``X-API-Key``) OR a logged-in
+  HomePilot session (JWT / ``homepilot_session`` cookie) OR a same-machine
+  request. It is **fail-closed** for anonymous remote callers — logs are never
+  served without proof of access, even when no ``API_KEY`` is configured.
+* SSE framing matches HF (``data: {"timestamp": ..., "data": ...}``); pass
+  ``?format=raw`` for plain lines. Heartbeats keep the stream alive through
+  nginx/Caddy, and ``X-Accel-Buffering: no`` disables proxy buffering.
+
+Query params: ``tail`` (initial lines, default 200), ``follow`` (default true —
+``tail -f`` semantics), ``format`` (``json`` | ``raw``), ``token`` (alternative
+to the Authorization header, handy for browser EventSource which cannot set
+headers).
+"""
+from __future__ import annotations
+
+import asyncio
+import hmac
+import json
+import os
+import time
+from datetime import datetime, timezone
+from typing import AsyncIterator, List, Optional
+
+from fastapi import APIRouter, Cookie, Header, HTTPException, Query, Request
+from fastapi.responses import JSONResponse, StreamingResponse
+
+from . import config as _cfg
+
+router = APIRouter(tags=["logs"])
+
+# Allowlist: stream name -> ordered candidate filenames (first existing wins).
+# Fixed names only — no user-supplied paths ⇒ no path traversal.
+_STREAMS: dict[str, List[str]] = {
+    # Hugging Face–compatible aliases
+    "run": ["backend-stderr.log", "backend-stdout.log", "supervisord.log"],
+    "build": ["supervisord.log"],
+    # Explicit per-service streams (nice for targeted debugging)
+    "backend": ["backend-stderr.log"],
+    "backend-stdout": ["backend-stdout.log"],
+    "nginx": ["nginx-stderr.log", "nginx-stdout.log"],
+    "comfyui": ["comfyui-stderr.log", "comfyui-stdout.log"],
+    "supervisord": ["supervisord.log"],
+}
+
+_LOCAL_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
+_HEARTBEAT_SECS = 15.0
+_POLL_SECS = 1.0
+_MAX_TAIL = 5000
+
+
+def _log_dir() -> str:
+    """Resolved at call time so desktop/dev installs can override via env."""
+    return os.getenv("HOMEPILOT_LOG_DIR", "/var/log/supervisor").rstrip("/") or "/var/log/supervisor"
+
+
+def _resolve_log_file(stream: str) -> Optional[str]:
+    """Map a stream name to an absolute file path inside the log dir.
+
+    Returns the first existing candidate, else the first candidate path (so a
+    follower can wait for a not-yet-created file). Returns ``None`` for an
+    unknown stream or if a resolved path would escape the log directory.
+    """
+    candidates = _STREAMS.get(stream)
+    if not candidates:
+        return None
+    base = os.path.realpath(_log_dir())
+    fallback: Optional[str] = None
+    for name in candidates:
+        p = os.path.realpath(os.path.join(base, name))
+        # Defense in depth: never escape the log directory.
+        if not (p == base or p.startswith(base + os.sep)):
+            continue
+        if fallback is None:
+            fallback = p
+        if os.path.isfile(p):
+            return p
+    return fallback
+
+
+def _extract_token(authorization: Optional[str], x_api_key: Optional[str], token_q: Optional[str]) -> Optional[str]:
+    if x_api_key and x_api_key.strip():
+        return x_api_key.strip()
+    if authorization:
+        parts = authorization.split(" ", 1)
+        if len(parts) == 2 and parts[0].lower() == "bearer":
+            return parts[1].strip()
+    if token_q and token_q.strip():
+        return token_q.strip()
+    return None
+
+
+def _authorize(
+    request: Request,
+    authorization: Optional[str],
+    x_api_key: Optional[str],
+    homepilot_session: Optional[str],
+    token_q: Optional[str],
+) -> None:
+    """Fail-closed authorization for log access. Raises 401 if unauthorized."""
+    supplied = _extract_token(authorization, x_api_key, token_q)
+
+    # 1. Shared API key (constant-time compare).
+    api_key = _cfg.API_KEY
+    if api_key and supplied and hmac.compare_digest(supplied, api_key):
+        return
+
+    # 2. Logged-in HomePilot user session (JWT bearer / query / cookie).
+    try:
+        from .users import _validate_token, ensure_users_tables
+
+        ensure_users_tables()
+        tok = supplied or (homepilot_session.strip() if homepilot_session else "")
+        if tok and _validate_token(tok):
+            return
+    except Exception:
+        pass
+
+    # 3. Same-machine request (curl on the box itself is trusted dev traffic).
+    try:
+        if request.client and request.client.host in _LOCAL_HOSTS:
+            return
+    except Exception:
+        pass
+
+    raise HTTPException(status_code=401, detail="Unauthorized: valid API key or session required")
+
+
+def _redact(line: str) -> str:
+    """Never echo the configured API key back in a log line."""
+    key = _cfg.API_KEY
+    if key and len(key) >= 8 and key in line:
+        line = line.replace(key, "***REDACTED***")
+    return line
+
+
+def _read_tail(path: str, n: int) -> List[str]:
+    """Return the last ``n`` lines. Supervisor caps files at a few MB, so
+    reading the whole file is cheap and avoids fragile seek arithmetic."""
+    if n <= 0 or not os.path.isfile(path):
+        return []
+    try:
+        with open(path, "r", errors="replace") as f:
+            lines = f.readlines()
+    except OSError:
+        return []
+    return [ln.rstrip("\n") for ln in lines[-n:]]
+
+
+def _sse(payload: str) -> str:
+    return f"data: {payload}\n\n"
+
+
+async def _event_stream(
+    path: str,
+    tail_n: int,
+    follow: bool,
+    fmt: str,
+    request: Request,
+) -> AsyncIterator[str]:
+    def render(line: str) -> str:
+        line = _redact(line)
+        if fmt == "raw":
+            return _sse(line)
+        return _sse(json.dumps(
+            {"timestamp": datetime.now(timezone.utc).isoformat(), "data": line},
+            ensure_ascii=False,
+        ))
+
+    # Opening comment — helps clients confirm the stream is live.
+    yield f": streaming {os.path.basename(path)} (follow={str(follow).lower()})\n\n"
+
+    if not os.path.isfile(path):
+        yield render(f"[logs] {os.path.basename(path)} not present yet at {_log_dir()} — waiting…")
+
+    # Initial tail.
+    for line in _read_tail(path, tail_n):
+        yield render(line)
+
+    if not follow:
+        return
+
+    # Follow loop (tail -f semantics), robust to rotation/truncation.
+    try:
+        offset = os.path.getsize(path) if os.path.isfile(path) else 0
+    except OSError:
+        offset = 0
+    buf = ""
+    last_emit = time.monotonic()
+
+    while True:
+        if await request.is_disconnected():
+            break
+        try:
+            if os.path.isfile(path):
+                size = os.path.getsize(path)
+                if size < offset:          # rotated / truncated
+                    offset, buf = 0, ""
+                if size > offset:
+                    with open(path, "r", errors="replace") as f:
+                        f.seek(offset)
+                        chunk = f.read()
+                        offset = f.tell()
+                    buf += chunk
+                    *complete, buf = buf.split("\n")
+                    for line in complete:
+                        yield render(line)
+                        last_emit = time.monotonic()
+        except Exception:
+            # Never let a transient read error kill the stream.
+            pass
+
+        if time.monotonic() - last_emit >= _HEARTBEAT_SECS:
+            yield ": keep-alive\n\n"
+            last_emit = time.monotonic()
+
+        await asyncio.sleep(_POLL_SECS)
+
+
+@router.get("/api/spaces/{owner}/{repo}/logs")
+async def list_space_logs(
+    owner: str,
+    repo: str,
+    request: Request,
+    authorization: Optional[str] = Header(default=None),
+    x_api_key: Optional[str] = Header(default=None, alias="X-API-Key"),
+    homepilot_session: Optional[str] = Cookie(default=None),
+    token: Optional[str] = Query(default=None),
+) -> JSONResponse:
+    """Discovery endpoint: which log streams exist and how big they are."""
+    _authorize(request, authorization, x_api_key, homepilot_session, token)
+    streams = {}
+    for name in _STREAMS:
+        f = _resolve_log_file(name)
+        exists = bool(f and os.path.isfile(f))
+        streams[name] = {
+            "available": exists,
+            "path": f,
+            "size_bytes": (os.path.getsize(f) if exists else 0),
+        }
+    return JSONResponse({
+        "ok": True,
+        "space": f"{owner}/{repo}",
+        "log_dir": _log_dir(),
+        "streams": streams,
+    })
+
+
+@router.get("/api/spaces/{owner}/{repo}/logs/{stream}")
+async def stream_space_logs(
+    owner: str,
+    repo: str,
+    stream: str,
+    request: Request,
+    tail: int = Query(default=200, ge=0, le=_MAX_TAIL),
+    follow: bool = Query(default=True),
+    fmt: str = Query(default="json", alias="format"),
+    authorization: Optional[str] = Header(default=None),
+    x_api_key: Optional[str] = Header(default=None, alias="X-API-Key"),
+    homepilot_session: Optional[str] = Cookie(default=None),
+    token: Optional[str] = Query(default=None),
+) -> StreamingResponse:
+    """Stream a log ``stream`` over SSE (``run``, ``build``, or a service name)."""
+    _authorize(request, authorization, x_api_key, homepilot_session, token)
+
+    if stream not in _STREAMS:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Unknown log stream '{stream}'. Available: {', '.join(sorted(_STREAMS))}",
+        )
+    path = _resolve_log_file(stream)
+    if not path:
+        raise HTTPException(status_code=404, detail="Log stream path could not be resolved")
+
+    normalized = "raw" if str(fmt).lower() == "raw" else "json"
+    headers = {
+        "Cache-Control": "no-cache, no-transform",
+        "X-Accel-Buffering": "no",   # nginx: don't buffer the SSE stream
+        "Connection": "keep-alive",
+    }
+    return StreamingResponse(
+        _event_stream(path, tail, follow, normalized, request),
+        media_type="text/event-stream",
+        headers=headers,
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -221,6 +221,16 @@ app.include_router(teams_router)
 from .teams.bridge_routes import router as teams_bridge_router
 app.include_router(teams_bridge_router)
 
+# Container log streaming (/api/spaces/<owner>/<repo>/logs/{run,build}) —
+# ADDITIVE, READ-ONLY. HF Spaces–style SSE log access for remote debugging,
+# gated by the shared API key or a logged-in session. Wrapped so a failure to
+# import this optional feature never takes the app down.
+try:
+    from .logs_api import router as logs_router
+    app.include_router(logs_router)
+except Exception as _e:  # pragma: no cover - defensive
+    print(f"[logs_api] disabled: {_e}")
+
 # --- Voice call (/v1/voice-call/*) — ADDITIVE, FEATURE-FLAGGED ---------------
 # Fully off by default. Enable with ``VOICE_CALL_ENABLED=true``. If anything
 # in the voice_call module raises on import (bad migration, missing dep, …)

--- a/backend/tests/test_logs_api.py
+++ b/backend/tests/test_logs_api.py
@@ -1,0 +1,123 @@
+"""Tests for the additive, read-only container log streaming API.
+
+Builds a minimal FastAPI app mounting only ``logs_api.router`` so we can drive
+auth and tailing deterministically without the full backend.
+"""
+import os
+import sys
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# Ensure the backend root (.../backend) is importable even if the session app
+# fixture (which does this in conftest) hasn't run yet.
+_BACKEND_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _BACKEND_ROOT not in sys.path:
+    sys.path.insert(0, _BACKEND_ROOT)
+
+from app import config as cfg  # noqa: E402
+from app.logs_api import router as logs_router  # noqa: E402
+
+SPACE = "/api/spaces/ruslanmv/HomePilot/logs"
+
+
+def _client(tmp_path, api_key="") -> TestClient:
+    cfg.API_KEY = api_key
+    os.environ["HOMEPILOT_LOG_DIR"] = str(tmp_path)
+    app = FastAPI()
+    app.include_router(logs_router)
+    return TestClient(app)
+
+
+def _seed(tmp_path, name, text):
+    p = tmp_path / name
+    p.write_text(text)
+    return p
+
+
+def test_anonymous_remote_denied_even_without_api_key(tmp_path):
+    # Fail-closed: no API key configured, TestClient host is not local → 401.
+    client = _client(tmp_path, api_key="")
+    r = client.get(f"{SPACE}/run", params={"follow": "false"})
+    assert r.status_code == 401
+
+
+def test_bad_api_key_denied(tmp_path):
+    client = _client(tmp_path, api_key="s3cret-key-value-1234567890")
+    r = client.get(f"{SPACE}/run", params={"follow": "false"},
+                   headers={"Authorization": "Bearer wrong"})
+    assert r.status_code == 401
+
+
+def test_run_stream_returns_tail_with_valid_key(tmp_path):
+    key = "s3cret-key-value-1234567890"
+    _seed(tmp_path, "backend-stderr.log", "line-one\nline-two\nline-three\n")
+    client = _client(tmp_path, api_key=key)
+    r = client.get(
+        f"{SPACE}/run",
+        params={"follow": "false", "format": "raw", "tail": "2"},
+        headers={"Authorization": f"Bearer {key}"},
+    )
+    assert r.status_code == 200
+    assert "text/event-stream" in r.headers["content-type"]
+    body = r.text
+    assert "line-three" in body and "line-two" in body
+    assert "line-one" not in body  # tail=2 dropped the oldest
+
+
+def test_x_api_key_header_and_json_format(tmp_path):
+    key = "s3cret-key-value-1234567890"
+    _seed(tmp_path, "supervisord.log", "spawned backend\nexited backend\n")
+    client = _client(tmp_path, api_key=key)
+    r = client.get(
+        f"{SPACE}/build",
+        params={"follow": "false"},   # default json format
+        headers={"X-API-Key": key},
+    )
+    assert r.status_code == 200
+    assert 'data: {"timestamp"' in r.text
+    assert "spawned backend" in r.text
+
+
+def test_api_key_redacted_in_output(tmp_path):
+    key = "supersecretkey1234567890abcdef"
+    _seed(tmp_path, "backend-stderr.log", f"leaked token {key} in a traceback\n")
+    client = _client(tmp_path, api_key=key)
+    r = client.get(
+        f"{SPACE}/run",
+        params={"follow": "false", "format": "raw"},
+        headers={"Authorization": f"Bearer {key}"},
+    )
+    assert r.status_code == 200
+    assert key not in r.text
+    assert "***REDACTED***" in r.text
+
+
+def test_unknown_stream_404(tmp_path):
+    key = "s3cret-key-value-1234567890"
+    client = _client(tmp_path, api_key=key)
+    r = client.get(f"{SPACE}/does-not-exist", params={"follow": "false"},
+                   headers={"Authorization": f"Bearer {key}"})
+    assert r.status_code == 404
+
+
+def test_discovery_lists_streams(tmp_path):
+    key = "s3cret-key-value-1234567890"
+    _seed(tmp_path, "backend-stderr.log", "hello\n")
+    client = _client(tmp_path, api_key=key)
+    r = client.get(f"{SPACE}", headers={"Authorization": f"Bearer {key}"})
+    assert r.status_code == 200
+    data = r.json()
+    assert data["ok"] is True
+    assert data["streams"]["run"]["available"] is True
+    assert data["streams"]["comfyui"]["available"] is False
+
+
+def test_token_query_param_auth(tmp_path):
+    # Browser EventSource can't set headers → token via query string works.
+    key = "s3cret-key-value-1234567890"
+    _seed(tmp_path, "backend-stderr.log", "via-query\n")
+    client = _client(tmp_path, api_key=key)
+    r = client.get(f"{SPACE}/run", params={"follow": "false", "format": "raw", "token": key})
+    assert r.status_code == 200
+    assert "via-query" in r.text


### PR DESCRIPTION
Additive, non-destructive feature to query a running deployment's logs over
SSE without SSH, mirroring Hugging Face Spaces:

  GET /api/spaces/{owner}/{repo}/logs          → list streams
  GET /api/spaces/{owner}/{repo}/logs/{stream} → stream over SSE

Streams: run (live app), build (boot/supervisord), backend, backend-stdout,
nginx, comfyui, supervisord. Query params: tail, follow (tail -f), format
(json HF-style | raw), token (for browser EventSource).

- New backend/app/logs_api.py: reads the supervisor log files the container
  already writes; never writes/mutates. Log dir is HOMEPILOT_LOG_DIR (default
  /var/log/supervisor) so web and desktop installs both work.
- Auth reuses the shared API_KEY (Bearer or X-API-Key) or a logged-in session
  or a same-machine request; fail-closed for anonymous remote callers. Config
  key value is redacted from streamed lines and compared constant-time.
- SSE robustness: initial tail then follow with rotation/truncation handling,
  heartbeats, and X-Accel-Buffering:no so it flows through nginx/Caddy.
- Mounted in main.py with one guarded include_router (import failure can't take
  the app down). Tests cover auth (fail-closed, bad key, header/query),
  tail/format/redaction/404/discovery; follow + heartbeat verified directly.
- Documented in API.md.