### PR TITLE
Unified model catalog + remote projects (Batches 8 & 9, additive)

### DIFF
--- a/backend/app/cloud_tokens.py
+++ b/backend/app/cloud_tokens.py
@@ -1,0 +1,141 @@
+"""
+Server-side per-user OllaBridge cloud token store (Batch 7 — BFF session).
+
+Moves the user's long-lived cloud credential OUT of the browser and into the
+HomePilot Web backend, keyed to the HomePilot user. The Account Mirror BFF and
+the cloud-relay chat path read it here instead of receiving it from the client.
+
+Storage: a single additive table in the app DB. At-rest encryption is OPT-IN:
+if ``cryptography`` is installed AND ``HOMEPILOT_CLOUD_TOKEN_KEY`` (a Fernet
+key) is set, values are encrypted ("f:" prefix); otherwise they are stored
+server-side as-is ("p:" prefix). Either way the token never lives in browser
+storage — the primary security goal. Legacy/unprefixed values are read as
+plaintext for forward-compat.
+
+ADDITIVE: new module + new table. Nothing else changes. All writes are gated by
+the caller (only invoked when HOMEPILOT_BFF_SESSION_ENABLED is on).
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import time
+from typing import Optional
+
+from .storage import _get_db_path
+
+_TABLE = "user_cloud_tokens"
+
+# Tri-state cache: None = not resolved, False = unavailable, object = Fernet.
+_fernet_cache: object = None
+
+
+def _fernet():
+    global _fernet_cache
+    if _fernet_cache is not None:
+        return _fernet_cache or None
+    key = os.getenv("HOMEPILOT_CLOUD_TOKEN_KEY", "").strip()
+    if not key:
+        _fernet_cache = False
+        return None
+    try:
+        from cryptography.fernet import Fernet
+        _fernet_cache = Fernet(key.encode())
+        return _fernet_cache
+    except Exception:
+        # Library missing or bad key — degrade to server-side plaintext.
+        _fernet_cache = False
+        return None
+
+
+def _encode(token: str) -> str:
+    f = _fernet()
+    if f:
+        try:
+            return "f:" + f.encrypt(token.encode()).decode()
+        except Exception:
+            pass
+    return "p:" + token
+
+
+def _decode(stored: str) -> Optional[str]:
+    if stored.startswith("f:"):
+        f = _fernet()
+        if not f:
+            return None
+        try:
+            return f.decrypt(stored[2:].encode()).decode()
+        except Exception:
+            return None
+    if stored.startswith("p:"):
+        return stored[2:]
+    return stored  # legacy unprefixed plaintext
+
+
+def ensure_table() -> None:
+    con = sqlite3.connect(_get_db_path())
+    try:
+        con.execute(
+            f"""
+            CREATE TABLE IF NOT EXISTS {_TABLE} (
+                user_id    TEXT PRIMARY KEY,
+                token_enc  TEXT NOT NULL,
+                updated_at REAL NOT NULL
+            )
+            """
+        )
+        con.commit()
+    finally:
+        con.close()
+
+
+def set_cloud_token(user_id: str, token: str) -> None:
+    """Persist (upsert) the user's cloud token, server-side only."""
+    if not user_id or not token:
+        return
+    ensure_table()
+    con = sqlite3.connect(_get_db_path())
+    try:
+        con.execute(
+            f"INSERT INTO {_TABLE}(user_id, token_enc, updated_at) VALUES (?,?,?) "
+            f"ON CONFLICT(user_id) DO UPDATE SET token_enc=excluded.token_enc, updated_at=excluded.updated_at",
+            (str(user_id), _encode(token), time.time()),
+        )
+        con.commit()
+    finally:
+        con.close()
+
+
+def get_cloud_token(user_id: str) -> Optional[str]:
+    """Return the user's cloud token, or None. Never raises."""
+    if not user_id:
+        return None
+    try:
+        ensure_table()
+        con = sqlite3.connect(_get_db_path())
+        try:
+            row = con.execute(
+                f"SELECT token_enc FROM {_TABLE} WHERE user_id = ?", (str(user_id),)
+            ).fetchone()
+        finally:
+            con.close()
+    except Exception:
+        return None
+    if not row or not row[0]:
+        return None
+    return _decode(row[0])
+
+
+def clear_cloud_token(user_id: str) -> None:
+    if not user_id:
+        return
+    try:
+        ensure_table()
+        con = sqlite3.connect(_get_db_path())
+        try:
+            con.execute(f"DELETE FROM {_TABLE} WHERE user_id = ?", (str(user_id),))
+            con.commit()
+        finally:
+            con.close()
+    except Exception:
+        pass

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -231,6 +231,18 @@ try:
 except Exception as _e:  # pragma: no cover - defensive
     print(f"[logs_api] disabled: {_e}")
 
+# Account Mirror BFF proxy (/v1/account/mirror/*) — ADDITIVE, FEATURE-FLAGGED
+# (HOMEPILOT_MIRROR_BFF_ENABLED). Same-origin, server-mediated path to the
+# OllaBridge Cloud mirror so the browser never holds cloud tokens or relay URLs.
+# Off by default → router not mounted; import guarded so it can never break boot.
+try:
+    from . import mirror_proxy as _mirror_proxy
+    if _mirror_proxy.is_enabled():
+        app.include_router(_mirror_proxy.router)
+        print("[mirror-bff] mounted /v1/account/mirror/*")
+except Exception as _e:  # pragma: no cover - defensive
+    print(f"[mirror-bff] disabled: {_e}")
+
 # --- Voice call (/v1/voice-call/*) — ADDITIVE, FEATURE-FLAGGED ---------------
 # Fully off by default. Enable with ``VOICE_CALL_ENABLED=true``. If anything
 # in the voice_call module raises on import (bad migration, missing dep, …)
@@ -4631,7 +4643,26 @@ async def chat(inp: ChatIn, authorization: str = Header(default=""), homepilot_s
     # never persisted, no cross-request leakage under asyncio.
     try:
         from .llm import PROVIDER_API_KEY as _provider_key_ctx
-        _provider_key_ctx.set((inp.provider_api_key or "").strip())
+        _pk = (inp.provider_api_key or "").strip()
+        # Batch 7 (BFF session): if the browser did NOT send a key but this is a
+        # cloud-relay target (openai_compat @ .../ollama/v1), inject the caller's
+        # server-side cloud token so the browser never has to hold it. Flagged +
+        # additive; falls through to whatever the client sent when off.
+        if not _pk:
+            try:
+                from .mirror_proxy import bff_session_enabled
+                if (
+                    bff_session_enabled()
+                    and (inp.provider or "").strip() == "openai_compat"
+                    and "/ollama/v1" in (inp.provider_base_url or "")
+                ):
+                    _u = _scoped_user_or_none(authorization=authorization, homepilot_session=homepilot_session)
+                    if _u:
+                        from .cloud_tokens import get_cloud_token
+                        _pk = (get_cloud_token(_u["id"]) or "").strip()
+            except Exception:
+                pass
+        _provider_key_ctx.set(_pk)
     except Exception:
         pass  # additive — never let credential plumbing break chat
 

--- a/backend/app/mirror_proxy.py
+++ b/backend/app/mirror_proxy.py
@@ -1,0 +1,417 @@
+"""
+Account Mirror BFF proxy (ADDITIVE, FEATURE-FLAGGED) — Batch 1.
+
+Gives the HomePilot **Web** frontend a single, same-origin, server-mediated
+path to the OllaBridge Cloud mirror. The browser talks only to this backend
+under ``/v1/account/mirror/*``; it never learns the cloud relay URL and never
+holds a cloud token. The token lives server-side and is attached here.
+
+Routes (thin, explicit — NOT an open proxy):
+
+    GET  /v1/account/mirror/status                         → is the feature usable
+    GET  /v1/account/mirror/nodes                          → cloud GET  /v1/mirror/nodes
+    GET  /v1/account/mirror/nodes/{node_id}/manifest       → cloud GET  …/manifest
+    POST /v1/account/mirror/nodes/{node_id}/rpc            → cloud POST …/rpc   (read-only allow-list)
+    POST /v1/account/mirror/nodes/{node_id}/jobs           → cloud POST …/jobs
+    GET  /v1/account/mirror/jobs/{job_id}?node_id=…        → cloud GET  /v1/mirror/jobs/{id}
+    POST /v1/account/mirror/jobs/{job_id}/cancel?node_id=… → cloud POST …/cancel
+
+Design / security posture
+-------------------------
+* **Feature-flagged.** ``HOMEPILOT_MIRROR_BFF_ENABLED`` (default off). When off,
+  ``main.py`` does not mount the router at all — zero behavior change.
+* **Additive & non-destructive.** New router only. Does not touch ``/chat``,
+  ``/v1/auth/*``, or any existing route.
+* **Fail-closed auth.** The caller must be an authenticated HomePilot user
+  (Bearer/JWT or ``homepilot_session`` cookie), resolved with the same helper
+  the rest of the app uses. Single-user self-host keeps its default-user
+  behavior; multi-user without a token → 401.
+* **Server-side credential.** The cloud bearer is resolved on the server via
+  ``_resolve_cloud_credentials`` — a per-user registry (the Batch-7 BFF seam)
+  with a fallback to the operator's ``OLLABRIDGE_CLOUD_TOKEN`` env. The token is
+  never read from, nor returned to, the browser, and is never logged.
+* **Least privilege.** Only the fixed mirror endpoints are reachable; RPC
+  operations are checked against a read-only allow-list mirroring the cloud's;
+  node/job ids are format-validated; request bodies are size-capped.
+* **Honest passthrough.** Upstream status codes that carry product meaning —
+  notably ``409 node_offline`` — are preserved so the UI can render offline
+  states instead of guessing. Transport failures map to 502/504. Bodies are
+  returned as-is (they contain no secrets); our own errors never echo the token.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import threading
+import time
+import uuid
+from typing import Any, Dict, Optional, Tuple
+
+import httpx
+from fastapi import APIRouter, Cookie, Header, HTTPException, Query, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+
+from . import config as _cfg
+
+logger = logging.getLogger("homepilot.mirror_proxy")
+
+router = APIRouter(prefix="/v1/account/mirror", tags=["account-mirror"])
+
+# Read-only RPC operations we forward — mirrors OllaBridge Cloud's
+# ``_ALLOWED_RPC_OPS``. Defense in depth: the cloud AND the owning node also
+# enforce their own whitelists. Keep this list in sync with the cloud's.
+_ALLOWED_RPC_OPS = frozenset({
+    "services.health", "node.manifest", "models.list", "personas.list",
+    "projects.list", "projects.get", "workflows.list", "settings.get_safe",
+})
+
+# Ids are opaque tokens from the cloud (device ids, job ids). Constrain the
+# charset so a caller can never smuggle path/query segments into the upstream
+# URL, independent of httpx's own encoding.
+_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
+
+# Body guard for rpc/job params so the proxy can't be used to shovel megabytes
+# of JSON at the cloud on someone else's token.
+_MAX_PARAMS_BYTES = 256 * 1024
+
+# Upstream timeouts (connect, read). Jobs creation is allowed to take longer.
+_CONNECT_TIMEOUT = 5.0
+_RPC_TIMEOUT = 30.0
+_JOB_CREATE_TIMEOUT = 60.0
+
+# ---------------------------------------------------------------------------
+# Feature flag
+# ---------------------------------------------------------------------------
+
+def is_enabled() -> bool:
+    return os.getenv("HOMEPILOT_MIRROR_BFF_ENABLED", "false").strip().lower() in {
+        "1", "true", "yes", "on",
+    }
+
+
+def bff_session_enabled() -> bool:
+    """Batch 7 (BFF session): store the cloud token server-side and inject it
+    into cloud-relay calls, so the browser never holds it. Off by default."""
+    return os.getenv("HOMEPILOT_BFF_SESSION_ENABLED", "false").strip().lower() in {
+        "1", "true", "yes", "on",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Per-user cloud credential registry — the Batch-7 BFF seam.
+#
+# Batch 7 (BFF session) will call ``register_cloud_token(user_id, token)`` right
+# after the ``/v1/auth/exchange`` validation so each user's own cloud token is
+# used. Until then the operator's ``OLLABRIDGE_CLOUD_TOKEN`` env is the
+# server-side fallback (correct for the single-operator web deployment). Kept
+# in-memory ONLY: this batch deliberately does not persist raw cloud tokens to
+# disk — encrypted at-rest storage belongs to Batch 7.
+# ---------------------------------------------------------------------------
+
+_registry_lock = threading.Lock()
+_USER_CLOUD_TOKENS: Dict[str, str] = {}
+
+
+def register_cloud_token(user_id: str, token: str) -> None:
+    """Associate a HomePilot user with their OllaBridge cloud bearer token."""
+    if not user_id or not token:
+        return
+    with _registry_lock:
+        _USER_CLOUD_TOKENS[str(user_id)] = token
+
+
+def clear_cloud_token(user_id: str) -> None:
+    with _registry_lock:
+        _USER_CLOUD_TOKENS.pop(str(user_id), None)
+
+
+def _cloud_base() -> str:
+    return (getattr(_cfg, "OLLABRIDGE_CLOUD_URL", "") or "").rstrip("/")
+
+
+def _resolve_cloud_credentials(user: Optional[Dict[str, Any]]) -> Tuple[str, str]:
+    """Return ``(base_url, bearer_token)`` for the cloud call, server-side only.
+
+    Order: per-user registered token (Batch 7) → operator env token. Raises 503
+    when neither is available so the frontend can surface "cloud not linked"
+    rather than a confusing 401 from upstream.
+    """
+    base = _cloud_base()
+    if not base:
+        raise HTTPException(status_code=503, detail="Cloud gateway not configured")
+
+    token: Optional[str] = None
+    if user and user.get("id"):
+        with _registry_lock:
+            token = _USER_CLOUD_TOKENS.get(str(user["id"]))
+        # Batch 7: fall back to the server-side per-user token store (survives
+        # restarts). In-memory registry stays a fast path.
+        if not token:
+            try:
+                from .cloud_tokens import get_cloud_token
+                token = get_cloud_token(str(user["id"]))
+            except Exception:
+                token = None
+    if not token:
+        token = (getattr(_cfg, "OLLABRIDGE_CLOUD_TOKEN", "") or "").strip() or None
+    if not token:
+        raise HTTPException(
+            status_code=503,
+            detail="Cloud account not linked. Configure OLLABRIDGE_CLOUD_TOKEN "
+                   "or sign in to link your account.",
+        )
+    return base, token
+
+
+# ---------------------------------------------------------------------------
+# Caller authentication (fail-closed, same semantics as the rest of the app)
+# ---------------------------------------------------------------------------
+
+def _require_user(authorization: Optional[str], homepilot_session: Optional[str]) -> Dict[str, Any]:
+    from .users import (  # lazy import avoids any import cycle with main
+        _validate_token,
+        count_users,
+        ensure_users_tables,
+        get_or_create_default_user,
+    )
+
+    ensure_users_tables()
+    token = ""
+    if authorization and authorization.lower().startswith("bearer "):
+        token = authorization.split(" ", 1)[1].strip()
+    if not token and homepilot_session:
+        token = homepilot_session.strip()
+
+    user = _validate_token(token) if token else None
+    if user:
+        return user
+    # No token: single-user self-host keeps working; multi-user must sign in.
+    if count_users() > 1:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    return get_or_create_default_user()
+
+
+# ---------------------------------------------------------------------------
+# Upstream call helper
+# ---------------------------------------------------------------------------
+
+def _validate_id(value: str, what: str) -> str:
+    if not _ID_RE.match(value or ""):
+        raise HTTPException(status_code=400, detail=f"Invalid {what}")
+    return value
+
+
+def _check_params(params: Any) -> Dict[str, Any]:
+    params = params or {}
+    if not isinstance(params, dict):
+        raise HTTPException(status_code=400, detail="params must be an object")
+    try:
+        if len(json.dumps(params)) > _MAX_PARAMS_BYTES:
+            raise HTTPException(status_code=413, detail="params too large")
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=400, detail="params must be JSON-serializable")
+    return params
+
+
+async def _forward(
+    *,
+    method: str,
+    path: str,
+    token: str,
+    base: str,
+    user_id: str,
+    params: Optional[Dict[str, Any]] = None,
+    json_body: Optional[Dict[str, Any]] = None,
+    read_timeout: float = _RPC_TIMEOUT,
+) -> JSONResponse:
+    """Perform the upstream mirror call and return a sanitized JSONResponse.
+
+    Passes the cloud's status code and JSON body through unchanged (they carry
+    product-meaningful signals like ``node_offline`` and contain no secrets).
+    Never forwards browser headers upstream, never logs or echoes the token.
+    """
+    rid = "mbff_" + uuid.uuid4().hex[:16]
+    url = f"{base}{path}"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+        "X-Request-Id": rid,
+    }
+    timeout = httpx.Timeout(read_timeout, connect=_CONNECT_TIMEOUT)
+    started = time.monotonic()
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.request(method, url, headers=headers, params=params, json=json_body)
+    except httpx.TimeoutException:
+        logger.warning("[mirror-bff %s] upstream timeout user=%s %s %s", rid, user_id, method, path)
+        return _err(504, "upstream_timeout", "The cloud gateway did not respond in time.", rid)
+    except httpx.RequestError as exc:
+        logger.warning("[mirror-bff %s] upstream error user=%s %s %s: %s", rid, user_id, method, path, type(exc).__name__)
+        return _err(502, "upstream_unreachable", "Could not reach the cloud gateway.", rid)
+
+    elapsed_ms = int((time.monotonic() - started) * 1000)
+    # Parse JSON defensively; the mirror always returns JSON, but never trust it.
+    try:
+        payload = resp.json()
+    except ValueError:
+        payload = {"error": "upstream_bad_response",
+                   "message": "Cloud gateway returned a non-JSON response."}
+    logger.info("[mirror-bff %s] user=%s %s %s -> %s (%dms)",
+                rid, user_id, method, path, resp.status_code, elapsed_ms)
+
+    body = payload if isinstance(payload, (dict, list)) else {"data": payload}
+    if isinstance(body, dict):
+        body.setdefault("request_id", rid)
+    return JSONResponse(status_code=resp.status_code, content=body,
+                        headers={"Cache-Control": "no-store"})
+
+
+def _err(status: int, code: str, message: str, rid: str) -> JSONResponse:
+    return JSONResponse(
+        status_code=status,
+        content={"error": code, "message": message, "request_id": rid},
+        headers={"Cache-Control": "no-store"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Request models
+# ---------------------------------------------------------------------------
+
+class RpcIn(BaseModel):
+    operation: str = Field(..., min_length=1, max_length=128)
+    params: Dict[str, Any] = Field(default_factory=dict)
+
+
+class JobIn(BaseModel):
+    operation: str = Field(..., min_length=1, max_length=128)
+    params: Dict[str, Any] = Field(default_factory=dict)
+    resource_uri: Optional[str] = Field(default=None, max_length=1024)
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+@router.get("/status")
+async def mirror_status(
+    authorization: Optional[str] = Header(default=None),
+    homepilot_session: Optional[str] = Cookie(default=None),
+) -> JSONResponse:
+    """Lightweight readiness probe for the frontend spine (Batch 2).
+
+    Reports whether the feature is usable for this caller — without exposing the
+    token. ``linked`` is true when a server-side cloud credential is resolvable.
+    """
+    user = _require_user(authorization, homepilot_session)
+    linked = True
+    try:
+        _resolve_cloud_credentials(user)
+    except HTTPException:
+        linked = False
+    return JSONResponse(
+        status_code=200,
+        content={"ok": True, "enabled": True, "linked": linked, "cloud": _cloud_base()},
+        headers={"Cache-Control": "no-store"},
+    )
+
+
+@router.get("/nodes")
+async def list_nodes(
+    authorization: Optional[str] = Header(default=None),
+    homepilot_session: Optional[str] = Cookie(default=None),
+) -> JSONResponse:
+    user = _require_user(authorization, homepilot_session)
+    base, token = _resolve_cloud_credentials(user)
+    return await _forward(method="GET", path="/v1/mirror/nodes", token=token,
+                          base=base, user_id=str(user.get("id", "")))
+
+
+@router.get("/nodes/{node_id}/manifest")
+async def node_manifest(
+    node_id: str,
+    authorization: Optional[str] = Header(default=None),
+    homepilot_session: Optional[str] = Cookie(default=None),
+) -> JSONResponse:
+    user = _require_user(authorization, homepilot_session)
+    _validate_id(node_id, "node_id")
+    base, token = _resolve_cloud_credentials(user)
+    return await _forward(method="GET", path=f"/v1/mirror/nodes/{node_id}/manifest",
+                          token=token, base=base, user_id=str(user.get("id", "")))
+
+
+@router.post("/nodes/{node_id}/rpc")
+async def node_rpc(
+    node_id: str,
+    body: RpcIn,
+    authorization: Optional[str] = Header(default=None),
+    homepilot_session: Optional[str] = Cookie(default=None),
+) -> JSONResponse:
+    user = _require_user(authorization, homepilot_session)
+    _validate_id(node_id, "node_id")
+    if body.operation not in _ALLOWED_RPC_OPS:
+        raise HTTPException(status_code=400, detail="Operation is not in the read-only mirror allow-list")
+    params = _check_params(body.params)
+    base, token = _resolve_cloud_credentials(user)
+    return await _forward(
+        method="POST", path=f"/v1/mirror/nodes/{node_id}/rpc", token=token, base=base,
+        user_id=str(user.get("id", "")),
+        json_body={"operation": body.operation, "params": params},
+    )
+
+
+@router.post("/nodes/{node_id}/jobs")
+async def create_job(
+    node_id: str,
+    body: JobIn,
+    authorization: Optional[str] = Header(default=None),
+    homepilot_session: Optional[str] = Cookie(default=None),
+) -> JSONResponse:
+    user = _require_user(authorization, homepilot_session)
+    _validate_id(node_id, "node_id")
+    params = _check_params(body.params)
+    payload: Dict[str, Any] = {"operation": body.operation, "params": params}
+    if body.resource_uri:
+        payload["resource_uri"] = body.resource_uri
+    base, token = _resolve_cloud_credentials(user)
+    return await _forward(
+        method="POST", path=f"/v1/mirror/nodes/{node_id}/jobs", token=token, base=base,
+        user_id=str(user.get("id", "")), json_body=payload, read_timeout=_JOB_CREATE_TIMEOUT,
+    )
+
+
+@router.get("/jobs/{job_id}")
+async def get_job(
+    job_id: str,
+    node_id: str = Query(..., description="Owning node id (ownership is re-checked upstream)"),
+    authorization: Optional[str] = Header(default=None),
+    homepilot_session: Optional[str] = Cookie(default=None),
+) -> JSONResponse:
+    user = _require_user(authorization, homepilot_session)
+    _validate_id(job_id, "job_id")
+    _validate_id(node_id, "node_id")
+    base, token = _resolve_cloud_credentials(user)
+    return await _forward(
+        method="GET", path=f"/v1/mirror/jobs/{job_id}", token=token, base=base,
+        user_id=str(user.get("id", "")), params={"node_id": node_id},
+    )
+
+
+@router.post("/jobs/{job_id}/cancel")
+async def cancel_job(
+    job_id: str,
+    node_id: str = Query(..., description="Owning node id (ownership is re-checked upstream)"),
+    authorization: Optional[str] = Header(default=None),
+    homepilot_session: Optional[str] = Cookie(default=None),
+) -> JSONResponse:
+    user = _require_user(authorization, homepilot_session)
+    _validate_id(job_id, "job_id")
+    _validate_id(node_id, "node_id")
+    base, token = _resolve_cloud_credentials(user)
+    return await _forward(
+        method="POST", path=f"/v1/mirror/jobs/{job_id}/cancel", token=token, base=base,
+        user_id=str(user.get("id", "")), params={"node_id": node_id},
+    )

--- a/backend/app/users.py
+++ b/backend/app/users.py
@@ -739,6 +739,18 @@ def exchange(body: ExchangeRequest, request: Request):
         set_cloud_link(created["id"], cloud_user_id, auth_provider="ollabridge")
         user = get_user_by_id(created["id"])
 
+    # Batch 7 (BFF session): persist the validated cloud token server-side so
+    # the browser never has to hold it. Gated by HOMEPILOT_BFF_SESSION_ENABLED;
+    # additive and best-effort — never break login on a storage hiccup.
+    try:
+        from .mirror_proxy import bff_session_enabled, register_cloud_token
+        if bff_session_enabled():
+            from .cloud_tokens import set_cloud_token
+            set_cloud_token(user["id"], body.cloud_token.strip())
+            register_cloud_token(user["id"], body.cloud_token.strip())
+    except Exception:
+        pass
+
     token = _create_token(user["id"])
     resp = JSONResponse({
         "ok": True,
@@ -762,6 +774,16 @@ def logout(authorization: str = Header(default="")):
     """Invalidate the current session token."""
     token = authorization.replace("Bearer ", "").strip()
     if token:
+        # Batch 7: also drop the server-side cloud token for this user on logout.
+        try:
+            _u = _validate_token(token)
+            if _u:
+                from .cloud_tokens import clear_cloud_token
+                from .mirror_proxy import clear_cloud_token as _clear_registry
+                clear_cloud_token(_u["id"])
+                _clear_registry(_u["id"])
+        except Exception:
+            pass
         _invalidate_token(token)
     resp = JSONResponse({"ok": True})
     resp.delete_cookie("homepilot_session", path="/")

--- a/backend/tests/test_cloud_tokens.py
+++ b/backend/tests/test_cloud_tokens.py
@@ -1,0 +1,61 @@
+"""Tests for the server-side cloud token store (Batch 7 — BFF session)."""
+import os
+import sys
+import tempfile
+
+_BACKEND_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _BACKEND_ROOT not in sys.path:
+    sys.path.insert(0, _BACKEND_ROOT)
+
+
+def _fresh_store():
+    os.environ["SQLITE_PATH"] = tempfile.mktemp(suffix=".db")
+    os.environ.pop("HOMEPILOT_CLOUD_TOKEN_KEY", None)
+    # Re-import fresh so the fernet cache + db path are clean.
+    for m in ("app.cloud_tokens",):
+        sys.modules.pop(m, None)
+    from app import cloud_tokens as ct
+    ct._fernet_cache = None  # reset tri-state cache
+    return ct
+
+
+def test_roundtrip_upsert_clear():
+    ct = _fresh_store()
+    assert ct.get_cloud_token("u1") is None
+    ct.set_cloud_token("u1", "tok-abc")
+    assert ct.get_cloud_token("u1") == "tok-abc"
+    ct.set_cloud_token("u1", "tok-xyz")   # upsert
+    assert ct.get_cloud_token("u1") == "tok-xyz"
+    ct.clear_cloud_token("u1")
+    assert ct.get_cloud_token("u1") is None
+
+
+def test_plaintext_prefixed_when_no_key():
+    ct = _fresh_store()
+    ct.set_cloud_token("u2", "plain-secret")
+    # Stored value carries the 'p:' prefix (server-side plaintext), never raw.
+    import sqlite3
+    con = sqlite3.connect(ct._get_db_path())
+    raw = con.execute("SELECT token_enc FROM user_cloud_tokens WHERE user_id='u2'").fetchone()[0]
+    con.close()
+    assert raw.startswith("p:") and raw.endswith("plain-secret")
+    assert ct.get_cloud_token("u2") == "plain-secret"
+
+
+def test_empty_inputs_are_noops():
+    ct = _fresh_store()
+    ct.set_cloud_token("", "x")      # no user
+    ct.set_cloud_token("u3", "")     # no token
+    assert ct.get_cloud_token("u3") is None
+    assert ct.get_cloud_token("") is None
+
+
+def test_legacy_unprefixed_read_as_plaintext():
+    ct = _fresh_store()
+    ct.ensure_table()
+    import sqlite3, time
+    con = sqlite3.connect(ct._get_db_path())
+    con.execute("INSERT INTO user_cloud_tokens(user_id, token_enc, updated_at) VALUES (?,?,?)",
+                ("u4", "legacy-raw", time.time()))
+    con.commit(); con.close()
+    assert ct.get_cloud_token("u4") == "legacy-raw"

--- a/backend/tests/test_mirror_proxy.py
+++ b/backend/tests/test_mirror_proxy.py
@@ -1,0 +1,211 @@
+"""Tests for the Account Mirror BFF proxy (Batch 1).
+
+Drives the router with a mocked OllaBridge Cloud upstream so we can assert
+forwarding, server-side token attachment (and non-leakage), status passthrough
+(incl. 409 node_offline), input validation, credential resolution, and
+transport error mapping — without a real cloud or the full app.
+"""
+import os
+import sys
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+_BACKEND_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _BACKEND_ROOT not in sys.path:
+    sys.path.insert(0, _BACKEND_ROOT)
+
+from app import mirror_proxy as mp  # noqa: E402
+
+
+# ── Fake upstream ────────────────────────────────────────────────────────────
+
+class _FakeResp:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        if isinstance(self._payload, ValueError):
+            raise self._payload
+        return self._payload
+
+
+class _FakeClient:
+    """Records the last upstream request and returns a scripted response."""
+    last = {}
+    script = {"status": 200, "payload": []}
+    raise_exc = None
+
+    def __init__(self, *a, **k):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def request(self, method, url, headers=None, params=None, json=None):
+        _FakeClient.last = {"method": method, "url": url, "headers": headers or {},
+                            "params": params, "json": json}
+        if _FakeClient.raise_exc is not None:
+            raise _FakeClient.raise_exc
+        return _FakeResp(_FakeClient.script["status"], _FakeClient.script["payload"])
+
+
+@pytest.fixture(autouse=True)
+def _wire(monkeypatch):
+    # Bypass DB-backed auth: every request is a fixed signed-in user.
+    monkeypatch.setattr(mp, "_require_user", lambda a, c: {"id": "user-1"})
+    # Deterministic cloud config.
+    monkeypatch.setattr(mp._cfg, "OLLABRIDGE_CLOUD_URL", "https://cloud.example", raising=False)
+    monkeypatch.setattr(mp._cfg, "OLLABRIDGE_CLOUD_TOKEN", "operator-token", raising=False)
+    # Mock the upstream HTTP client.
+    monkeypatch.setattr(mp.httpx, "AsyncClient", _FakeClient)
+    _FakeClient.last = {}
+    _FakeClient.raise_exc = None
+    _FakeClient.script = {"status": 200, "payload": []}
+    with mp._registry_lock:
+        mp._USER_CLOUD_TOKENS.clear()
+    yield
+
+
+def _client():
+    app = FastAPI()
+    app.include_router(mp.router)
+    return TestClient(app)
+
+
+# ── Flag parsing ─────────────────────────────────────────────────────────────
+
+def test_is_enabled_env(monkeypatch):
+    monkeypatch.delenv("HOMEPILOT_MIRROR_BFF_ENABLED", raising=False)
+    assert mp.is_enabled() is False
+    for v in ("1", "true", "YES", "on"):
+        monkeypatch.setenv("HOMEPILOT_MIRROR_BFF_ENABLED", v)
+        assert mp.is_enabled() is True
+    monkeypatch.setenv("HOMEPILOT_MIRROR_BFF_ENABLED", "off")
+    assert mp.is_enabled() is False
+
+
+# ── Forwarding + token attachment ────────────────────────────────────────────
+
+def test_list_nodes_forwards_and_attaches_token():
+    _FakeClient.script = {"status": 200, "payload": [{"id": "node-a", "online": True}]}
+    r = _client().get("/v1/account/mirror/nodes")
+    assert r.status_code == 200
+    assert r.json()[0]["id"] == "node-a"
+    # Went to the right upstream path with the server-side bearer.
+    assert _FakeClient.last["url"] == "https://cloud.example/v1/mirror/nodes"
+    assert _FakeClient.last["headers"]["Authorization"] == "Bearer operator-token"
+    # No-store so mirror data isn't cached by the browser.
+    assert r.headers["cache-control"] == "no-store"
+
+
+def test_token_never_leaks_to_client():
+    _FakeClient.script = {"status": 200, "payload": [{"id": "n"}]}
+    r = _client().get("/v1/account/mirror/nodes")
+    assert "operator-token" not in r.text
+    assert "authorization" not in {k.lower() for k in r.headers}
+
+
+def test_per_user_token_preferred_over_operator():
+    mp.register_cloud_token("user-1", "per-user-token")
+    _client().get("/v1/account/mirror/nodes")
+    assert _FakeClient.last["headers"]["Authorization"] == "Bearer per-user-token"
+
+
+def test_node_offline_409_preserved():
+    _FakeClient.script = {"status": 409, "payload": {"error": "node_offline", "node_id": "n1"}}
+    r = _client().get("/v1/account/mirror/nodes/n1/manifest")
+    assert r.status_code == 409
+    assert r.json()["error"] == "node_offline"
+
+
+# ── RPC allow-list + validation ──────────────────────────────────────────────
+
+def test_rpc_allowed_op_forwards():
+    _FakeClient.script = {"status": 200, "payload": {"ok": True}}
+    r = _client().post("/v1/account/mirror/nodes/n1/rpc",
+                       json={"operation": "projects.list", "params": {}})
+    assert r.status_code == 200
+    assert _FakeClient.last["json"] == {"operation": "projects.list", "params": {}}
+
+
+def test_rpc_disallowed_op_rejected_without_upstream_call():
+    _FakeClient.last = {}
+    r = _client().post("/v1/account/mirror/nodes/n1/rpc",
+                       json={"operation": "shell.exec", "params": {}})
+    assert r.status_code == 400
+    assert _FakeClient.last == {}  # never forwarded
+
+
+def test_invalid_node_id_rejected():
+    r = _client().get("/v1/account/mirror/nodes/bad%2Fid/manifest")
+    assert r.status_code in (400, 404)  # our 400, or path-not-matched
+
+
+def test_oversized_params_rejected():
+    big = {"x": "a" * (300 * 1024)}
+    r = _client().post("/v1/account/mirror/nodes/n1/rpc",
+                       json={"operation": "projects.list", "params": big})
+    assert r.status_code == 413
+
+
+# ── Jobs ─────────────────────────────────────────────────────────────────────
+
+def test_create_job_forwards_resource_uri():
+    _FakeClient.script = {"status": 202, "payload": {"job_id": "job-1"}}
+    r = _client().post("/v1/account/mirror/nodes/n1/jobs",
+                       json={"operation": "chat", "params": {"m": "hi"},
+                             "resource_uri": "hpnode://n1/model/x"})
+    assert r.status_code == 202
+    assert _FakeClient.last["json"]["resource_uri"] == "hpnode://n1/model/x"
+
+
+def test_get_job_requires_node_id():
+    r = _client().get("/v1/account/mirror/jobs/job-1")   # missing node_id
+    assert r.status_code == 422
+
+
+def test_get_job_passes_node_id_query():
+    _FakeClient.script = {"status": 200, "payload": {"status": "running"}}
+    r = _client().get("/v1/account/mirror/jobs/job-1", params={"node_id": "n1"})
+    assert r.status_code == 200
+    assert _FakeClient.last["params"] == {"node_id": "n1"}
+    assert _FakeClient.last["url"] == "https://cloud.example/v1/mirror/jobs/job-1"
+
+
+# ── Credential resolution ────────────────────────────────────────────────────
+
+def test_missing_credentials_returns_503(monkeypatch):
+    monkeypatch.setattr(mp._cfg, "OLLABRIDGE_CLOUD_TOKEN", "", raising=False)
+    r = _client().get("/v1/account/mirror/nodes")
+    assert r.status_code == 503
+
+
+def test_status_reports_linked_without_exposing_token():
+    r = _client().get("/v1/account/mirror/status")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["linked"] is True and body["enabled"] is True
+    assert "operator-token" not in r.text
+
+
+# ── Transport error mapping ──────────────────────────────────────────────────
+
+def test_upstream_timeout_maps_504():
+    _FakeClient.raise_exc = httpx.TimeoutException("slow")
+    r = _client().get("/v1/account/mirror/nodes")
+    assert r.status_code == 504
+    assert r.json()["error"] == "upstream_timeout"
+
+
+def test_upstream_error_maps_502():
+    _FakeClient.raise_exc = httpx.ConnectError("boom")
+    r = _client().get("/v1/account/mirror/nodes")
+    assert r.status_code == 502
+    assert r.json()["error"] == "upstream_unreachable"

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,13 @@ import ReactDOM from 'react-dom/client'
 import App from './ui/App'
 import AuthGate from './ui/components/AuthGate'
 import LegalPage from './ui/components/LegalPage'
+// Account & Computers spine (Batch 2) — ADDITIVE. The providers render children
+// unchanged and do NO network unless the feature flag is on; the dev panel
+// renders null unless the mirror debug flag is on. Zero behavior change by default.
+import { HomePilotAccountProvider } from './ui/account/HomePilotAccountProvider'
+import { ComputerProvider } from './ui/account/ComputerContext'
+import { MirrorDevPanel } from './ui/account/MirrorDevPanel'
+import { RemoteOfflineBanner } from './ui/account/RemoteOfflineBanner'
 import './ui/styles.css'
 
 // Public, pre-auth legal pages. These are reached by full navigation (the login
@@ -18,7 +25,13 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
       <LegalPage kind={legalKind} />
     ) : (
       <AuthGate>
-        <App />
+        <HomePilotAccountProvider>
+          <ComputerProvider>
+            <App />
+            <RemoteOfflineBanner />
+            <MirrorDevPanel />
+          </ComputerProvider>
+        </HomePilotAccountProvider>
       </AuthGate>
     )}
   </React.StrictMode>,

--- a/frontend/src/ui/App.tsx
+++ b/frontend/src/ui/App.tsx
@@ -37,6 +37,17 @@ import {
 } from 'lucide-react'
 import SettingsPanel, { type SettingsModelV2, type HardwarePresetUI } from './SettingsPanel'
 import { getDefaultBackendUrl, resolveBackendUrl } from './lib/backendUrl'
+// Account & Computers header pill (Batch 4) — ADDITIVE; renders null when the
+// Account & Computers flag is off, so the header is unchanged by default.
+import { ComputerStatusPill } from './account/ComputerStatusPill'
+// Remote-LLM chat routing (Batch 5) — resolves the cloud-relay target when a
+// remote computer is selected; null (local path unchanged) otherwise.
+// Batch 6 adds useSelectedOfflineNode — a pinned-but-offline computer, used to
+// block silent Web-CPU fallback.
+import { useRemoteChatTarget, useSelectedOfflineNode } from './account/useRemoteChatTarget'
+// BFF session flag (Batch 7) — when on, the browser stops sending the cloud
+// token; the backend injects it server-side.
+import { isBffSessionEnabled } from './account/featureFlags'
 import ProfileSettingsModal from './ProfileSettingsModal'
 import UserAvatar from './components/UserAvatar'
 import AccountMenu, { type AccountMenuUser } from './components/AccountMenu'
@@ -291,6 +302,9 @@ type Mode = 'chat' | 'voice' | 'search' | 'project' | 'imagine' | 'edit' | 'anim
  */
 function cloudProviderApiKey(baseUrl?: string): string | undefined {
   if (!baseUrl || !baseUrl.includes('/ollama/v1')) return undefined
+  // Batch 7 (BFF): when the backend holds the cloud token server-side it injects
+  // it into the relay call; the browser sends nothing. Off → legacy behavior.
+  if (isBffSessionEnabled()) return undefined
   try { return localStorage.getItem('homepilot_cloud_token') || undefined } catch { return undefined }
 }
 type ChatReasoningMode = 'persona' | 'fast' | 'expert' | 'heavy'
@@ -2054,6 +2068,9 @@ function ChatState({
           not a styling of the header. */}
       <div className="fixed top-3 right-5 z-50">
         <div className="relative flex items-center gap-2">
+          {/* Live computer/presence pill (Batch 4). Null unless the Account &
+              Computers flag is on and a computer exists. */}
+          <ComputerStatusPill />
           {onStartCall && (() => {
             return (
               <button
@@ -2955,7 +2972,35 @@ export default function App() {
   }, [])
 
 
+  // Batch 5: transparent remote-LLM routing. When the Account & Computers flag
+  // is on and the user picked an online remote computer, this resolves the cloud
+  // relay target for that node's chat model; otherwise it's null. Held in a ref
+  // so the synchronous currentChatSelection() below can read the latest value.
+  const remoteChatTarget = useRemoteChatTarget()
+  const remoteChatTargetRef = useRef(remoteChatTarget)
+  useEffect(() => { remoteChatTargetRef.current = remoteChatTarget }, [remoteChatTarget])
+
+  // Batch 6: a pinned computer that is offline. When set, sends are blocked
+  // rather than silently downgraded to Web CPU. Held in a ref for the send guard.
+  const selectedOfflineNode = useSelectedOfflineNode()
+  const selectedOfflineNodeRef = useRef(selectedOfflineNode)
+  useEffect(() => { selectedOfflineNodeRef.current = selectedOfflineNode }, [selectedOfflineNode])
+
+  // Troubleshoot in the offline banner asks to open settings.
+  useEffect(() => {
+    const onOpen = () => setShowSettings(true)
+    window.addEventListener('homepilot:open-settings', onOpen)
+    return () => window.removeEventListener('homepilot:open-settings', onOpen)
+  }, [setShowSettings])
+
   const currentChatSelection = useCallback(() => {
+    // If a remote computer is selected, swap the target to the cloud relay bound
+    // to that node's model (same wire shape as "Use for Chat"). The cloud token
+    // is attached downstream by cloudProviderApiKey() for /ollama/v1 base URLs.
+    const remote = remoteChatTargetRef.current
+    if (remote) {
+      return { providerChat: 'openai_compat', modelChat: remote.model, baseUrlChat: remote.baseUrl }
+    }
     const providerChat = localStorage.getItem('homepilot_provider_chat') || settingsDraft.providerChat || 'ollama'
     const modelChat = localStorage.getItem('homepilot_model_chat') || settingsDraft.modelChat || ''
     const baseUrlChat = localStorage.getItem('homepilot_base_url_chat') || settingsDraft.baseUrlChat || ''
@@ -3697,6 +3742,14 @@ export default function App() {
       const trimmed = rawText.trim()
       if (!trimmed) return
 
+      // Batch 6: honest offline. If the user pinned a specific computer that is
+      // offline, do NOT silently run on Web CPU — block the send and surface the
+      // offline banner (which explains + offers Troubleshoot / Notify / Automatic).
+      if (selectedOfflineNodeRef.current) {
+        window.dispatchEvent(new CustomEvent('homepilot:remote-offline-nudge'))
+        return
+      }
+
       setShowSettings(false)
 
       // user-visible message stays as typed; request uses mode prefixes
@@ -3873,6 +3926,7 @@ export default function App() {
                   provider: chatSelection.providerChat,
                   provider_base_url: chatSelection.baseUrlChat || undefined,
                   provider_model: chatSelection.modelChat,
+                  provider_api_key: cloudProviderApiKey(chatSelection.baseUrlChat),
                   temperature: settingsDraft.textTemperature ?? 0.7,
                   max_tokens: settingsDraft.textMaxTokens ?? 900,
                   vision_provider: settingsDraft.providerMultimodal || 'ollama',
@@ -3994,6 +4048,7 @@ export default function App() {
                   provider: chatSelection.providerChat,
                   provider_base_url: chatSelection.baseUrlChat || undefined,
                   provider_model: chatSelection.modelChat,
+                  provider_api_key: cloudProviderApiKey(chatSelection.baseUrlChat),
                   textTemperature: settingsDraft.textTemperature,
                   textMaxTokens: mode === 'voice' ? undefined : settingsDraft.textMaxTokens,
                   nsfwMode: settingsDraft.nsfwMode,
@@ -4255,6 +4310,7 @@ ${personalityPrompt || 'You are a friendly voice assistant. Be helpful and warm.
               provider: chatSelection.providerChat,
               provider_base_url: chatSelection.baseUrlChat || undefined,
               provider_model: chatSelection.modelChat,
+              provider_api_key: cloudProviderApiKey(chatSelection.baseUrlChat),
               temperature: settingsDraft.textTemperature ?? 0.7,
               max_tokens: mode === 'voice' ? 300 : (settingsDraft.textMaxTokens ?? 900),
               vision_provider: settingsDraft.providerMultimodal || 'ollama',

--- a/frontend/src/ui/Models.tsx
+++ b/frontend/src/ui/Models.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState, useCallback } from 'react'
 import { Download, RefreshCw, Copy, CheckCircle2, AlertTriangle, XCircle, Settings2, Key, X, Trash2, Shield, ExternalLink } from 'lucide-react'
 import OllaBridgeModels from './components/OllaBridgeModels'
+import { isAccountsUxEnabled } from './account/featureFlags'
 
 // -----------------------------------------------------------------------------
 // Types
@@ -2077,7 +2078,7 @@ export default function ModelsView(props: ModelsParams) {
               synced from the user's linked HomePilot / GPU nodes (relay), shown
               for whichever Model Type tab is active. When selected it replaces
               the local catalog for this tab. */}
-          {provider === 'ollabridge' ? (
+          {provider === 'ollabridge' && !isAccountsUxEnabled() ? (
             <OllaBridgeModels filterType={modelType} />
           ) : (
           <>

--- a/frontend/src/ui/ProjectsView.tsx
+++ b/frontend/src/ui/ProjectsView.tsx
@@ -1,5 +1,8 @@
 import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { resolveFileUrl } from './resolveFileUrl';
+// Remote projects (Batch 9) — ADDITIVE; renders null when the Account &
+// Computers flag is off, so the Projects page is unchanged by default.
+import { RemoteProjects } from './account/RemoteProjects';
 import {
   FolderKanban,
   Plus,
@@ -2082,6 +2085,9 @@ export default function ProjectsView({
 
       {/* Content */}
       <div className="flex-1 overflow-y-auto p-6">
+        {/* Batch 9: projects stored on the account's other computers.
+            Self-gates on the Account & Computers flag (null when off). */}
+        {activeTab === 'My Projects' && <RemoteProjects />}
         {activeTab === 'My Projects' && (
           <>
             {projects.length === 0 ? (

--- a/frontend/src/ui/SettingsPanel.tsx
+++ b/frontend/src/ui/SettingsPanel.tsx
@@ -22,6 +22,12 @@ import {
 } from "lucide-react";
 import OllamaHealthBanner from "./OllamaHealthBanner";
 import OllaBridgeLink from "./components/OllaBridgeLink";
+// Account & Computers (Batch 3) — ADDITIVE, feature-flagged.
+import AccountComputers from "./account/AccountComputers";
+import { isAccountsUxEnabled } from "./account/featureFlags";
+// Unified model catalog (Batch 8) + relocated OllaBridge provider.
+import { UnifiedModelCatalog } from "./account/UnifiedModelCatalog";
+import OllaBridgeModels from "./components/OllaBridgeModels";
 import ProfileSettingsModal from "./ProfileSettingsModal";
 import TtsEngineSection from "./components/TtsEngineSection";
 // Side-effect import: registers the bundled TTS providers (web-speech-api,
@@ -286,6 +292,10 @@ function StatusPill({ ok, label }: { ok: boolean; label: string }) {
 const SECTIONS = [
   { id: "general", label: "General", Icon: SettingsIcon },
   { id: "connection", label: "Connection", Icon: Link2 },
+  // Account & Computers (Batch 3). Shown in place of "OllaBridge Link" only when
+  // the feature flag is on; otherwise it is filtered out and behavior is
+  // unchanged. See `visibleSections` below.
+  { id: "account", label: "Account & Computers", Icon: Cloud },
   { id: "linking", label: "OllaBridge Link", Icon: Cloud },
   { id: "providers", label: "Providers", Icon: Server },
   { id: "models", label: "Models", Icon: Boxes },
@@ -418,6 +428,19 @@ export default function SettingsPanel({
 
   // ── Enterprise modal shell state ───────────────────────────────────────
   const [activeSection, setActiveSection] = useState<SectionId>("connection");
+
+  // Sidebar sections, adjusted for the Account & Computers flag (Batch 3):
+  //  - flag OFF: hide "account" → today's list, unchanged.
+  //  - flag ON : hide "OllaBridge Link" from the primary nav (still reachable
+  //    from Advanced, not deleted) and relabel "OllaBridge API" → "API Access".
+  const accountsUx = isAccountsUxEnabled();
+  const visibleSections = React.useMemo(
+    () =>
+      SECTIONS.filter((s) => (accountsUx ? s.id !== "linking" : s.id !== "account")).map((s) =>
+        accountsUx && s.id === "ollabridge" ? { ...s, label: "API Access" } : s,
+      ),
+    [accountsUx],
+  );
   const [showApiKey, setShowApiKey] = useState(false);
   const [copiedKey, setCopiedKey] = useState(false);
   const [testing, setTesting] = useState(false);
@@ -981,6 +1004,7 @@ export default function SettingsPanel({
 
   function renderProviders() {
     return (
+      <>
       <SettingsCard
         title="Providers"
         description="Choose which backend powers each capability."
@@ -1002,11 +1026,19 @@ export default function SettingsPanel({
         {providerSelectRow("Video Provider", "Used for video generation.", value.providerVideo, (k) => commit({ ...value, providerVideo: k }))}
         {providerSelectRow("Multimodal Provider", "Used for image understanding (vision).", value.providerMultimodal || 'ollama', (k) => commit({ ...value, providerMultimodal: k }))}
       </SettingsCard>
+      {/* Batch 8: the OllaBridge provider is relocated here (under Providers)
+          when the Account & Computers UX is on — no longer a primary Models tab. */}
+      {accountsUx && <OllaBridgeModels />}
+      </>
     );
   }
 
   function renderModels() {
     return (
+      <>
+      {/* Batch 8: unified catalog of models on the account's computers.
+          Self-gates on the Account & Computers flag (null when off). */}
+      <UnifiedModelCatalog />
       <SettingsCard
         title="Model Endpoints"
         description="Optional base URLs and the specific model for each provider."
@@ -1024,6 +1056,7 @@ export default function SettingsPanel({
         {baseUrlRow("Multimodal Base URL", value.providerMultimodal || 'ollama', value.baseUrlMultimodal, (v) => commit({ ...value, baseUrlMultimodal: v }))}
         {modelSelectRow("Multimodal Model", value.providerMultimodal || 'ollama', value.modelMultimodal || '', (m) => commit({ ...value, modelMultimodal: m }), value.baseUrlMultimodal, 'multimodal')}
       </SettingsCard>
+      </>
     );
   }
 
@@ -1422,6 +1455,17 @@ export default function SettingsPanel({
         description="Experimental and developer options. Change with care."
         icon={<FlaskConical size={16} />}
       >
+        {accountsUx && (
+          <Row label="OllaBridge Link (diagnostics)" description="Low-level account link, relay, and pairing details. Superseded by Account & Computers.">
+            <button
+              type="button"
+              onClick={() => setActiveSection("linking")}
+              className="text-[11px] px-3 py-1.5 rounded-xl bg-white/5 hover:bg-white/10 border border-white/10 text-white/70"
+            >
+              Open OllaBridge Link
+            </button>
+          </Row>
+        )}
         <Row label="Experimental: Civitai" description="Enable Civitai model downloads (image/video only).">
           <Toggle label="Experimental Civitai" tone="blue" checked={!!value.experimentalCivitai} onChange={(v) => commit({ ...value, experimentalCivitai: v })} />
         </Row>
@@ -1453,6 +1497,7 @@ export default function SettingsPanel({
     switch (activeSection) {
       case "general": return renderGeneral();
       case "connection": return renderConnection();
+      case "account": return <AccountComputers />;
       case "linking": return <OllaBridgeLink />;
       case "providers": return renderProviders();
       case "models": return renderModels();
@@ -1513,7 +1558,7 @@ export default function SettingsPanel({
             aria-label="Settings sections"
             className="hidden md:flex md:flex-col gap-1 w-56 shrink-0 p-3 border-r border-white/[0.08] bg-[#17181a] overflow-y-auto"
           >
-            {SECTIONS.map(({ id, label, Icon }) => {
+            {visibleSections.map(({ id, label, Icon }) => {
               const active = activeSection === id;
               return (
                 <button
@@ -1543,7 +1588,7 @@ export default function SettingsPanel({
             aria-label="Settings sections"
             className="md:hidden flex gap-1.5 overflow-x-auto px-3 py-2 border-b border-white/[0.08] bg-[#17181a] shrink-0"
           >
-            {SECTIONS.map(({ id, label, Icon }) => {
+            {visibleSections.map(({ id, label, Icon }) => {
               const active = activeSection === id;
               return (
                 <button

--- a/frontend/src/ui/account/AccountComputers.tsx
+++ b/frontend/src/ui/account/AccountComputers.tsx
@@ -1,0 +1,407 @@
+/**
+ * AccountComputers (Batch 3) — the "Account & Computers" settings tab.
+ *
+ * Renders the redesigned screen (one account, multiple computers, clear remote
+ * access) driven entirely by the Batch-2 spine (useAccount / useComputer →
+ * MirrorClient → BFF → cloud). ADDITIVE and shown only when the
+ * Account & Computers feature flag is on.
+ *
+ * Interaction model (design §10 of the tab spec):
+ *  - Connection actions apply immediately: Refresh, select computer, Sign Out.
+ *  - Sharing/permissions are a draft that commits on the panel's Save.
+ *
+ * Controls that require cloud/local endpoints not yet built (toggle a remote
+ * machine's remote-access, rename, pairing, policy enforcement) are rendered
+ * faithfully but guarded — disabled with a note — so nothing is faked.
+ */
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  Activity, ChevronRight, Cpu, ExternalLink, Globe, Monitor, Pencil, Plus,
+  RefreshCw, ShieldCheck, User, Users,
+} from 'lucide-react'
+
+import { resolveBackendUrl } from '../lib/backendUrl'
+import { getCurrentUserId, userScopedKey } from '../lib/userScopedStorage'
+import { useAccount } from './HomePilotAccountProvider'
+import { useComputer } from './ComputerContext'
+import { MirrorError, mirrorClient } from './mirrorClient'
+import type { MirrorNode, NodeManifest, PresenceState } from './types'
+
+const LS_PRIVACY = 'homepilot_sharing_level'
+type PrivacyLevel = 'only_me' | 'team' | 'advanced'
+
+// ── small presentational helpers ─────────────────────────────────────────────
+
+function StatusDot({ state }: { state: PresenceState }) {
+  const color =
+    state === 'online' ? 'bg-emerald-400'
+      : state === 'attention' ? 'bg-amber-400'
+        : 'bg-white/30'
+  return <span className={`inline-block w-2 h-2 rounded-full ${color}`} />
+}
+
+function Badge({ state, children }: { state: PresenceState; children: React.ReactNode }) {
+  const cls =
+    state === 'online' ? 'bg-emerald-500/15 text-emerald-300 border-emerald-500/30'
+      : state === 'attention' ? 'bg-amber-500/15 text-amber-300 border-amber-500/30'
+        : 'bg-white/5 text-white/50 border-white/10'
+  return (
+    <span className={`text-[10px] px-2 py-0.5 rounded-full border ${cls}`}>{children}</span>
+  )
+}
+
+function Card({ title, right, children }: { title?: string; right?: React.ReactNode; children: React.ReactNode }) {
+  return (
+    <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+      {(title || right) && (
+        <div className="flex items-center justify-between mb-3">
+          {title && <h3 className="text-sm font-semibold text-white/80">{title}</h3>}
+          {right}
+        </div>
+      )}
+      {children}
+    </div>
+  )
+}
+
+function readPrivacy(): PrivacyLevel {
+  try {
+    const uid = getCurrentUserId()
+    const v = localStorage.getItem(uid ? userScopedKey(LS_PRIVACY, uid) : `${LS_PRIVACY}:user:anon`)
+    if (v === 'team' || v === 'advanced' || v === 'only_me') return v
+  } catch { /* ignore */ }
+  return 'only_me'
+}
+function writePrivacy(v: PrivacyLevel): void {
+  try {
+    const uid = getCurrentUserId()
+    localStorage.setItem(uid ? userScopedKey(LS_PRIVACY, uid) : `${LS_PRIVACY}:user:anon`, v)
+  } catch { /* ignore */ }
+}
+
+// ── main ─────────────────────────────────────────────────────────────────────
+
+export default function AccountComputers(): JSX.Element {
+  const { status, computers, loading, error, notLinked, refresh } = useAccount()
+  const { selectedComputerId, selectComputer, presenceOf, anyOnline } = useComputer()
+
+  const [email, setEmail] = useState<string>('')
+  const [manifests, setManifests] = useState<Record<string, NodeManifest | null>>({})
+  const [privacy, setPrivacy] = useState<PrivacyLevel>(() => readPrivacy())
+
+  // Account email — read from the existing session endpoint (read-only).
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      try {
+        const tok = localStorage.getItem('homepilot_auth_token') || ''
+        const res = await fetch(`${resolveBackendUrl()}/v1/auth/me`, {
+          headers: tok ? { Authorization: `Bearer ${tok}` } : {},
+          credentials: 'include',
+        })
+        if (!res.ok) return
+        const data = await res.json()
+        if (!cancelled) setEmail(data?.email || data?.user?.email || '')
+      } catch { /* ignore */ }
+    })()
+    return () => { cancelled = true }
+  }, [])
+
+  // Lazily fetch manifests for ONLINE computers (offline → relay 409).
+  useEffect(() => {
+    let cancelled = false
+    computers.filter((c) => c.online && manifests[c.node_id] === undefined).forEach(async (c) => {
+      try {
+        const m = await mirrorClient.getManifest(c.node_id)
+        if (!cancelled) setManifests((prev) => ({ ...prev, [c.node_id]: m }))
+      } catch (e) {
+        if (!(e instanceof MirrorError && e.isNodeOffline) && !cancelled) {
+          setManifests((prev) => ({ ...prev, [c.node_id]: null }))
+        }
+      }
+    })
+    return () => { cancelled = true }
+  }, [computers, manifests])
+
+  const thisComputer: MirrorNode | null = useMemo(() => {
+    return computers.find((c) => c.node_id === selectedComputerId)
+      ?? computers.find((c) => c.online)
+      ?? computers[0]
+      ?? null
+  }, [computers, selectedComputerId])
+
+  const onSignOut = useCallback(() => {
+    try {
+      localStorage.removeItem('homepilot_auth_token')
+      localStorage.removeItem('homepilot_cloud_token')
+    } catch { /* ignore */ }
+    // Full reload returns to the AuthGate sign-in screen.
+    window.location.reload()
+  }, [])
+
+  const onManageAccount = useCallback(() => {
+    const url = status?.cloud
+    if (url) window.open(url, '_blank', 'noopener,noreferrer')
+  }, [status])
+
+  const onChangePrivacy = useCallback((v: PrivacyLevel) => {
+    setPrivacy(v)
+    // Persist the intent locally (per-user). Server-side policy enforcement is
+    // wired in a later batch; this is the draft the panel's Save commits.
+    writePrivacy(v)
+  }, [])
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="flex items-start justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-white">Account &amp; Computers</h2>
+          <p className="text-xs text-white/50 mt-0.5">Access your HomePilot from anywhere with your linked computers.</p>
+        </div>
+        <button
+          type="button"
+          title="HomePilot securely connects to your own computers. AI processing and project data stay on those computers unless you enable another storage option."
+          className="text-[11px] px-3 py-1.5 rounded-xl bg-white/5 hover:bg-white/10 border border-white/10 text-white/60"
+        >
+          ? What is this?
+        </button>
+      </div>
+
+      {/* Your Account */}
+      <Card title="Your Account">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-3 min-w-0">
+            <div className="w-10 h-10 rounded-full bg-violet-500/20 border border-violet-400/30 grid place-items-center">
+              <User size={18} className="text-violet-200" />
+            </div>
+            <div className="min-w-0">
+              <div className="flex items-center gap-2">
+                <span className="text-sm text-white/90 truncate">{email || 'Signed in'}</span>
+                <Badge state="online">Connected</Badge>
+              </div>
+              <div className="text-xs text-white/45">Your HomePilot account is active and secure.</div>
+            </div>
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
+            <button onClick={onManageAccount} disabled={!status?.cloud}
+              className="text-[11px] px-3 py-1.5 rounded-xl bg-white/5 hover:bg-white/10 border border-white/10 text-white/70 disabled:opacity-40 inline-flex items-center gap-1">
+              Manage Account <ExternalLink size={12} />
+            </button>
+            <button onClick={onSignOut}
+              className="text-[11px] px-3 py-1.5 rounded-xl bg-red-500/10 hover:bg-red-500/20 border border-red-500/20 text-red-300">
+              Sign Out
+            </button>
+          </div>
+        </div>
+      </Card>
+
+      {notLinked && (
+        <Card>
+          <div className="text-sm text-white/70">
+            No computer is linked to this account yet. Install HomePilot Local on a
+            computer with your models and projects, sign in with this same account,
+            and enable remote access.
+          </div>
+        </Card>
+      )}
+
+      {/* This Computer + Your Computers */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        {/* This Computer */}
+        <Card title="This Computer">
+          {thisComputer ? (
+            <ThisComputer node={thisComputer} manifest={manifests[thisComputer.node_id]} presence={presenceOf(thisComputer.node_id)} />
+          ) : (
+            <div className="text-sm text-white/50 py-6 text-center">
+              {loading ? 'Loading…' : 'No active computer yet.'}
+            </div>
+          )}
+        </Card>
+
+        {/* Your Computers */}
+        <Card
+          title="Your Computers"
+          right={
+            <button
+              type="button"
+              title="Pairing a new computer arrives in a later update."
+              className="text-[11px] px-3 py-1.5 rounded-xl bg-violet-500/80 hover:bg-violet-500 text-white inline-flex items-center gap-1"
+            >
+              <Plus size={13} /> Add Computer
+            </button>
+          }
+        >
+          {error && <div className="text-xs text-red-300 mb-2">{error}</div>}
+          <div className="space-y-2">
+            {computers.map((c) => {
+              const st = presenceOf(c.node_id)
+              const m = manifests[c.node_id]
+              const selected = c.node_id === selectedComputerId
+              return (
+                <button
+                  key={c.node_id}
+                  onClick={() => selectComputer(selected ? null : c.node_id)}
+                  className={`w-full text-left rounded-xl border px-3 py-2.5 flex items-center gap-3 transition-colors ${
+                    selected ? 'border-violet-400/50 bg-violet-500/10' : 'border-white/10 bg-white/[0.02] hover:bg-white/[0.05]'
+                  }`}
+                >
+                  <div className="w-9 h-9 rounded-lg bg-white/5 grid place-items-center shrink-0 relative">
+                    <Monitor size={16} className="text-white/70" />
+                    <span className="absolute -bottom-0.5 -right-0.5"><StatusDot state={st} /></span>
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm text-white/90 truncate">{c.node_name || c.node_id}</span>
+                      <Badge state={st}>{st === 'online' ? 'Online' : 'Offline'}</Badge>
+                    </div>
+                    <div className="text-[11px] text-white/45 truncate">{summarize(c, m)}</div>
+                  </div>
+                  <ChevronRight size={16} className="text-white/30 shrink-0" />
+                </button>
+              )
+            })}
+            {computers.length === 0 && !loading && !notLinked && (
+              <div className="text-xs text-white/45 py-4 text-center">No computers found.</div>
+            )}
+            <button
+              onClick={refresh}
+              className="w-full text-[11px] text-white/50 hover:text-white/80 inline-flex items-center justify-center gap-1 pt-1"
+            >
+              <RefreshCw size={12} className={loading ? 'animate-spin' : ''} /> Refresh
+            </button>
+          </div>
+        </Card>
+      </div>
+
+      {/* Privacy & Sharing (draft → commits on Save) */}
+      <Card
+        title="Privacy &amp; Sharing"
+        right={<span className="text-[11px] text-white/40">Choose who can use your computers and data.</span>}
+      >
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          <PrivacyOption
+            active={privacy === 'only_me'} onClick={() => onChangePrivacy('only_me')}
+            Icon={User} title="Only Me" desc="Only you can access your computers"
+          />
+          <PrivacyOption
+            active={privacy === 'team'} onClick={() => onChangePrivacy('team')}
+            Icon={Users} title="My Team" desc="Team members you invite can access"
+          />
+          <PrivacyOption
+            active={privacy === 'advanced'} onClick={() => onChangePrivacy('advanced')}
+            Icon={Globe} title="Advanced Sharing" desc="Custom rules and permissions"
+          />
+        </div>
+      </Card>
+    </div>
+  )
+}
+
+function summarize(c: MirrorNode, m: NodeManifest | null | undefined): string {
+  const parts: string[] = []
+  if (m?.gpu?.name) parts.push(String(m.gpu.name))
+  if (typeof m?.gpu?.vram_mb === 'number') parts.push(`${Math.round(m.gpu.vram_mb / 1024)} GB VRAM`)
+  if (Array.isArray(m?.models)) parts.push(`${m!.models.length} models`)
+  if (Array.isArray(m?.projects)) parts.push(`${m!.projects.length} projects`)
+  if (parts.length === 0) {
+    if (!c.online) return 'Offline'
+    return c.platform ? String(c.platform) : 'Online'
+  }
+  return parts.join(' · ')
+}
+
+function ThisComputer({ node, manifest, presence }: { node: MirrorNode; manifest: NodeManifest | null | undefined; presence: PresenceState }) {
+  const gpu = manifest?.gpu?.name
+  const vram = typeof manifest?.gpu?.vram_mb === 'number' ? `${Math.round(manifest.gpu.vram_mb / 1024)} GB VRAM` : ''
+  const os = manifest?.os || node.platform || ''
+  return (
+    <div className="space-y-4">
+      <div className="flex items-start gap-3">
+        <div className="w-12 h-12 rounded-xl bg-violet-500/15 border border-violet-400/20 grid place-items-center shrink-0">
+          <Monitor size={20} className="text-violet-200" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-semibold text-white/90 truncate">{node.node_name || node.node_id}</span>
+            <button title="Rename from HomePilot Local" className="text-white/30 hover:text-white/60"><Pencil size={13} /></button>
+            <span className="ml-auto inline-flex items-center gap-1 text-[11px] text-white/60">
+              <StatusDot state={presence} /> {presence === 'online' ? 'Online' : 'Offline'}
+            </span>
+          </div>
+          <div className="text-[11px] text-white/45 mt-0.5">
+            {[gpu, vram].filter(Boolean).join(' · ') || 'Details unavailable'}
+          </div>
+          <div className="text-[11px] text-white/45">{[os, 'HomePilot Local'].filter(Boolean).join(' · ')}</div>
+        </div>
+      </div>
+
+      {/* Provider-managed controls — reflected read-only on Web. */}
+      <div className="space-y-2 text-sm">
+        <Row label="Remote Access" note="Managed on the computer">
+          <Toggle on={presence === 'online'} disabled />
+        </Row>
+        <Row label="Available To" note="">
+          <span className="text-white/60 text-[12px]">Only me</span>
+        </Row>
+        <Row label="Start with HomePilot" note="Managed on the computer">
+          <span className="text-emerald-300 text-[11px] inline-flex items-center gap-1"><StatusDot state="online" /> On</span>
+        </Row>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2">
+        <button className="text-[11px] px-3 py-2 rounded-xl bg-white/5 hover:bg-white/10 border border-white/10 text-white/70 inline-flex items-center justify-center gap-1">
+          <Activity size={13} /> Diagnostics
+        </button>
+        <button title="Rename from HomePilot Local" className="text-[11px] px-3 py-2 rounded-xl bg-white/5 hover:bg-white/10 border border-white/10 text-white/70 inline-flex items-center justify-center gap-1">
+          <Pencil size={13} /> Rename
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function Row({ label, note, children }: { label: string; note?: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-center justify-between">
+      <div className="flex items-center gap-2">
+        <ShieldCheck size={14} className="text-white/30" />
+        <span className="text-white/70 text-[13px]">{label}</span>
+        {note && <span className="text-white/30 text-[10px]">· {note}</span>}
+      </div>
+      {children}
+    </div>
+  )
+}
+
+function Toggle({ on, disabled }: { on: boolean; disabled?: boolean }) {
+  return (
+    <span
+      className={`inline-flex w-9 h-5 rounded-full p-0.5 transition-colors ${on ? 'bg-emerald-500/70' : 'bg-white/15'} ${disabled ? 'opacity-60' : ''}`}
+    >
+      <span className={`w-4 h-4 rounded-full bg-white transition-transform ${on ? 'translate-x-4' : ''}`} />
+    </span>
+  )
+}
+
+function PrivacyOption({ active, onClick, Icon, title, desc }: {
+  active: boolean; onClick: () => void; Icon: typeof User; title: string; desc: string
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`text-left rounded-2xl border p-3 flex items-start gap-3 transition-colors ${
+        active ? 'border-violet-400/60 bg-violet-500/10' : 'border-white/10 bg-white/[0.02] hover:bg-white/[0.05]'
+      }`}
+    >
+      <div className={`w-8 h-8 rounded-lg grid place-items-center shrink-0 ${active ? 'bg-violet-500/25' : 'bg-white/5'}`}>
+        <Icon size={16} className={active ? 'text-violet-200' : 'text-white/60'} />
+      </div>
+      <div className="min-w-0">
+        <div className="text-[13px] text-white/90">{title}</div>
+        <div className="text-[11px] text-white/45">{desc}</div>
+      </div>
+      <span className={`ml-auto w-4 h-4 rounded-full border shrink-0 ${active ? 'border-violet-400 bg-violet-500' : 'border-white/25'}`} />
+    </button>
+  )
+}

--- a/frontend/src/ui/account/ComputerContext.tsx
+++ b/frontend/src/ui/account/ComputerContext.tsx
@@ -1,0 +1,140 @@
+/**
+ * ComputerContext (Batch 2) — where AI work should run.
+ *
+ * Design §11: a shared context holding `selectedComputer`, `selectionMode`, and
+ * per-computer presence/capabilities. This first cut is READ-ONLY toward the
+ * backend: it only reflects the account's computers (from HomePilotAccountProvider)
+ * and remembers a local selection preference. It does not yet route execution
+ * (that is Batch 5) or mutate anything server-side.
+ */
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
+
+import { getCurrentUserId, userScopedKey } from '../lib/userScopedStorage'
+import { useAccount } from './HomePilotAccountProvider'
+import type { MirrorNode, PresenceState, SelectionMode } from './types'
+
+const LS_SELECTED = 'homepilot_selected_computer'
+const LS_MODE = 'homepilot_selection_mode'
+
+function readScoped(baseKey: string): string | null {
+  try {
+    const uid = getCurrentUserId()
+    return localStorage.getItem(uid ? userScopedKey(baseKey, uid) : `${baseKey}:user:anon`)
+  } catch {
+    return null
+  }
+}
+function writeScoped(baseKey: string, value: string | null): void {
+  try {
+    const uid = getCurrentUserId()
+    const key = uid ? userScopedKey(baseKey, uid) : `${baseKey}:user:anon`
+    if (value == null) localStorage.removeItem(key)
+    else localStorage.setItem(key, value)
+  } catch {
+    /* ignore */
+  }
+}
+
+export interface ComputerContextValue {
+  /** All linked computers (mirrors the account provider). */
+  computers: MirrorNode[]
+  /** The node_id the user picked, or null in automatic/ask mode. */
+  selectedComputerId: string | null
+  /** The resolved selected computer object, if online & known. */
+  selectedComputer: MirrorNode | null
+  selectionMode: SelectionMode
+  /** Presence lookup by node_id. */
+  presenceOf: (nodeId: string) => PresenceState
+  /** True if at least one computer is online. */
+  anyOnline: boolean
+  /** Pick a specific computer (switches mode to 'fixed'). */
+  selectComputer: (nodeId: string | null) => void
+  setSelectionMode: (mode: SelectionMode) => void
+}
+
+const DEFAULT: ComputerContextValue = {
+  computers: [],
+  selectedComputerId: null,
+  selectedComputer: null,
+  selectionMode: 'automatic',
+  presenceOf: () => 'unknown',
+  anyOnline: false,
+  selectComputer: () => {},
+  setSelectionMode: () => {},
+}
+
+const ComputerCtx = createContext<ComputerContextValue>(DEFAULT)
+
+export function ComputerProvider({ children }: { children: React.ReactNode }): JSX.Element {
+  const { computers, enabled } = useAccount()
+
+  const [selectedComputerId, setSelectedId] = useState<string | null>(() => readScoped(LS_SELECTED))
+  const [selectionMode, setModeState] = useState<SelectionMode>(() => {
+    const m = readScoped(LS_MODE)
+    return m === 'fixed' || m === 'ask' || m === 'automatic' ? m : 'automatic'
+  })
+
+  const selectComputer = useCallback((nodeId: string | null) => {
+    setSelectedId(nodeId)
+    writeScoped(LS_SELECTED, nodeId)
+    // Choosing a specific machine implies a fixed preference.
+    const nextMode: SelectionMode = nodeId ? 'fixed' : 'automatic'
+    setModeState(nextMode)
+    writeScoped(LS_MODE, nextMode)
+  }, [])
+
+  const setSelectionMode = useCallback((mode: SelectionMode) => {
+    setModeState(mode)
+    writeScoped(LS_MODE, mode)
+    if (mode !== 'fixed') {
+      setSelectedId(null)
+      writeScoped(LS_SELECTED, null)
+    }
+  }, [])
+
+  // If the selected computer disappears from the account, drop the stale pick.
+  useEffect(() => {
+    if (!enabled) return
+    if (selectedComputerId && computers.length > 0 &&
+        !computers.some((c) => c.node_id === selectedComputerId)) {
+      selectComputer(null)
+    }
+  }, [enabled, computers, selectedComputerId, selectComputer])
+
+  const presenceOf = useCallback((nodeId: string): PresenceState => {
+    const c = computers.find((x) => x.node_id === nodeId)
+    if (!c) return 'unknown'
+    return c.online ? 'online' : 'offline'
+  }, [computers])
+
+  const selectedComputer = useMemo(
+    () => computers.find((c) => c.node_id === selectedComputerId) ?? null,
+    [computers, selectedComputerId],
+  )
+  const anyOnline = useMemo(() => computers.some((c) => c.online), [computers])
+
+  const value = useMemo<ComputerContextValue>(() => ({
+    computers,
+    selectedComputerId,
+    selectedComputer,
+    selectionMode,
+    presenceOf,
+    anyOnline,
+    selectComputer,
+    setSelectionMode,
+  }), [computers, selectedComputerId, selectedComputer, selectionMode, presenceOf, anyOnline, selectComputer, setSelectionMode])
+
+  return <ComputerCtx.Provider value={value}>{children}</ComputerCtx.Provider>
+}
+
+/** Read the shared computer-selection state. Safe outside a provider. */
+export function useComputer(): ComputerContextValue {
+  return useContext(ComputerCtx)
+}

--- a/frontend/src/ui/account/ComputerStatusPill.tsx
+++ b/frontend/src/ui/account/ComputerStatusPill.tsx
@@ -1,0 +1,124 @@
+/**
+ * ComputerStatusPill (Batch 4) — the header "Studio PC · Online" control.
+ *
+ * Binds to the Batch-2 spine (ComputerContext + HomePilotAccountProvider) and
+ * shows live presence WITHOUT a manual Refresh — the account provider already
+ * polls `/v1/account/mirror/nodes` on an interval (a cloud SSE presence stream
+ * will make this <10s in a later cloud batch). Clicking opens the Journey-B
+ * picker (Automatic / a specific computer); selection updates ComputerContext
+ * only — it does NOT route execution yet (that is Batch 5).
+ *
+ * ADDITIVE: renders `null` unless the Account & Computers flag is on and there
+ * is at least one computer, so dropping it into the header changes nothing by
+ * default.
+ */
+import React, { useEffect, useRef, useState } from 'react'
+import { ChevronDown, Monitor } from 'lucide-react'
+
+import { useAccount } from './HomePilotAccountProvider'
+import { useComputer } from './ComputerContext'
+import type { PresenceState } from './types'
+
+function dotClass(state: PresenceState): string {
+  return state === 'online' ? 'bg-emerald-400'
+    : state === 'attention' ? 'bg-amber-400'
+      : 'bg-white/30'
+}
+
+export function ComputerStatusPill(): JSX.Element | null {
+  const { enabled, computers, loading, refresh } = useAccount()
+  const { selectedComputer, selectionMode, presenceOf, anyOnline, selectComputer, setSelectionMode } = useComputer()
+
+  const [open, setOpen] = useState(false)
+  const rootRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const onDoc = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', onDoc)
+    return () => document.removeEventListener('mousedown', onDoc)
+  }, [open])
+
+  // Additive: invisible unless enabled and there is something to show.
+  if (!enabled || computers.length === 0) return null
+
+  // Resolve the pill's label + presence.
+  let label: string
+  let state: PresenceState
+  if (selectionMode === 'fixed' && selectedComputer) {
+    label = selectedComputer.node_name || selectedComputer.node_id
+    state = presenceOf(selectedComputer.node_id) // offline fixed pick → 'offline' (attention)
+    if (state === 'offline') state = 'attention'
+  } else if (computers.length === 1) {
+    const c = computers[0]
+    label = c.node_name || c.node_id
+    state = presenceOf(c.node_id)
+  } else {
+    label = 'Automatic'
+    state = anyOnline ? 'online' : 'offline'
+  }
+
+  return (
+    <div className="relative" ref={rootRef}>
+      <button
+        type="button"
+        onClick={() => { if (!open) refresh(); setOpen((v) => !v) }}
+        className="h-9 pl-2.5 pr-2 flex items-center gap-1.5 rounded-full bg-white/5 border border-white/10 text-white/70 hover:bg-white/10 hover:text-white transition-colors max-w-[220px]"
+        title="Where AI tasks run"
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        <span className={`w-2 h-2 rounded-full ${dotClass(state)} shrink-0`} />
+        <span className="text-[12px] truncate">{label}</span>
+        <ChevronDown size={14} className="text-white/40 shrink-0" />
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 mt-2 w-64 rounded-2xl border border-white/10 bg-[#17181a] shadow-2xl p-1.5 z-[60]"
+        >
+          <button
+            role="menuitem"
+            onClick={() => { setSelectionMode('automatic'); setOpen(false) }}
+            className={`w-full text-left px-3 py-2 rounded-xl flex items-center gap-2 text-[13px] ${
+              selectionMode !== 'fixed' ? 'bg-violet-500/15 text-white' : 'text-white/70 hover:bg-white/5'
+            }`}
+          >
+            <span className={`w-2 h-2 rounded-full ${anyOnline ? 'bg-emerald-400' : 'bg-white/30'}`} />
+            <span className="flex-1">Automatic</span>
+            <span className="text-[10px] text-white/40">recommended</span>
+          </button>
+
+          <div className="my-1 h-px bg-white/10" />
+
+          {computers.map((c) => {
+            const st = presenceOf(c.node_id)
+            const active = selectionMode === 'fixed' && selectedComputer?.node_id === c.node_id
+            return (
+              <button
+                key={c.node_id}
+                role="menuitem"
+                onClick={() => { selectComputer(c.node_id); setOpen(false) }}
+                className={`w-full text-left px-3 py-2 rounded-xl flex items-center gap-2 text-[13px] ${
+                  active ? 'bg-violet-500/15 text-white' : 'text-white/70 hover:bg-white/5'
+                }`}
+              >
+                <span className={`w-2 h-2 rounded-full ${dotClass(st)} shrink-0`} />
+                <Monitor size={13} className="text-white/40 shrink-0" />
+                <span className="flex-1 truncate">{c.node_name || c.node_id}</span>
+                <span className="text-[10px] text-white/40">{st === 'online' ? 'Online' : 'Offline'}</span>
+              </button>
+            )
+          })}
+
+          <div className="px-3 pt-1.5 pb-1 text-[10px] text-white/30">
+            {loading ? 'Updating…' : 'Updates automatically'}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/ui/account/HomePilotAccountProvider.tsx
+++ b/frontend/src/ui/account/HomePilotAccountProvider.tsx
@@ -1,0 +1,150 @@
+/**
+ * HomePilotAccountProvider (Batch 2) — shared account + computers state.
+ *
+ * Design §11: one provider owns the signed-in account and the list of
+ * computers, so individual components stop re-deriving it. This first cut is
+ * ADDITIVE and READ-ONLY: it is backed by the EXISTING HomePilot auth token
+ * (it does not change AuthScreen — that is strangled in Batch 7), and it does
+ * NO network at all unless the Account & Computers feature flag is on.
+ */
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+
+import { isAccountsUxEnabled } from './featureFlags'
+import { MirrorError, mirrorClient } from './mirrorClient'
+import type { MirrorNode, MirrorStatus } from './types'
+
+export interface AccountContextValue {
+  /** Whether the Account & Computers experience is enabled at all. */
+  enabled: boolean
+  /** BFF/cloud readiness; null until first probe. */
+  status: MirrorStatus | null
+  /** The account's computers (empty until loaded / when disabled). */
+  computers: MirrorNode[]
+  loading: boolean
+  /** Human-readable error, or null. `notLinked` distinguishes the common
+   *  "no cloud credential yet" case so the UI can show onboarding, not an error. */
+  error: string | null
+  notLinked: boolean
+  lastUpdated: number | null
+  /** Manually refetch status + computers. */
+  refresh: () => void
+}
+
+const DEFAULT: AccountContextValue = {
+  enabled: false,
+  status: null,
+  computers: [],
+  loading: false,
+  error: null,
+  notLinked: false,
+  lastUpdated: null,
+  refresh: () => {},
+}
+
+const AccountCtx = createContext<AccountContextValue>(DEFAULT)
+
+// Light presence poll while enabled and the tab is visible. Batch 4 replaces
+// this with a push presence stream; kept modest here to avoid chatter.
+const POLL_MS = 20_000
+
+export function HomePilotAccountProvider({ children }: { children: React.ReactNode }): JSX.Element {
+  const enabled = isAccountsUxEnabled()
+
+  const [status, setStatus] = useState<MirrorStatus | null>(null)
+  const [computers, setComputers] = useState<MirrorNode[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [notLinked, setNotLinked] = useState(false)
+  const [lastUpdated, setLastUpdated] = useState<number | null>(null)
+
+  const abortRef = useRef<AbortController | null>(null)
+  const tickRef = useRef(0)
+
+  const load = useCallback(async () => {
+    if (!enabled) return
+    abortRef.current?.abort()
+    const ctrl = new AbortController()
+    abortRef.current = ctrl
+    setLoading(true)
+    try {
+      const st = await mirrorClient.status(ctrl.signal)
+      setStatus(st)
+      if (!st.linked) {
+        // Not linked yet is an expected onboarding state, not an error.
+        setComputers([])
+        setNotLinked(true)
+        setError(null)
+        setLastUpdated(Date.now())
+        return
+      }
+      setNotLinked(false)
+      const nodes = await mirrorClient.listNodes(ctrl.signal)
+      setComputers(nodes)
+      setError(null)
+      setLastUpdated(Date.now())
+    } catch (e) {
+      if (ctrl.signal.aborted) return
+      if (e instanceof MirrorError && e.isNotLinked) {
+        setNotLinked(true)
+        setComputers([])
+        setError(null)
+      } else {
+        setError(e instanceof Error ? e.message : 'Failed to load computers')
+      }
+      setLastUpdated(Date.now())
+    } finally {
+      if (!ctrl.signal.aborted) setLoading(false)
+    }
+  }, [enabled])
+
+  const refresh = useCallback(() => {
+    tickRef.current += 1
+    void load()
+  }, [load])
+
+  // Initial load + visibility-aware polling. Entirely inert when disabled.
+  useEffect(() => {
+    if (!enabled) return
+    void load()
+    let timer: ReturnType<typeof setInterval> | null = null
+    const start = () => {
+      if (timer) return
+      timer = setInterval(() => {
+        if (typeof document === 'undefined' || document.visibilityState === 'visible') void load()
+      }, POLL_MS)
+    }
+    const stop = () => {
+      if (timer) { clearInterval(timer); timer = null }
+    }
+    start()
+    const onVis = () => {
+      if (document.visibilityState === 'visible') { void load(); start() } else { stop() }
+    }
+    document.addEventListener('visibilitychange', onVis)
+    return () => {
+      stop()
+      document.removeEventListener('visibilitychange', onVis)
+      abortRef.current?.abort()
+    }
+  }, [enabled, load])
+
+  const value = useMemo<AccountContextValue>(
+    () => ({ enabled, status, computers, loading, error, notLinked, lastUpdated, refresh }),
+    [enabled, status, computers, loading, error, notLinked, lastUpdated, refresh],
+  )
+
+  return <AccountCtx.Provider value={value}>{children}</AccountCtx.Provider>
+}
+
+/** Read the shared account state. Safe outside a provider (returns defaults). */
+export function useAccount(): AccountContextValue {
+  return useContext(AccountCtx)
+}

--- a/frontend/src/ui/account/MirrorDevPanel.tsx
+++ b/frontend/src/ui/account/MirrorDevPanel.tsx
@@ -1,0 +1,94 @@
+/**
+ * MirrorDevPanel (Batch 2) — dev-only proof that the spine works.
+ *
+ * Renders nothing unless the mirror debug flag is on (`?mirrorDebug=1` or
+ * `localStorage.homepilot_mirror_debug = '1'`). When visible it lists the
+ * account's computers with live online state, sourced entirely through
+ * MirrorClient → BFF → cloud. This satisfies the Batch-2 exit criterion without
+ * touching any product UI.
+ *
+ * Self-contained inline styles so it never depends on (or perturbs) the app's
+ * design system.
+ */
+import React from 'react'
+
+import { isMirrorDebug } from './featureFlags'
+import { useAccount } from './HomePilotAccountProvider'
+import { useComputer } from './ComputerContext'
+import type { PresenceState } from './types'
+
+const DOT: Record<PresenceState, string> = {
+  online: '#22c55e',
+  offline: '#6b7280',
+  attention: '#f59e0b',
+  unknown: '#6b7280',
+}
+
+export function MirrorDevPanel(): JSX.Element | null {
+  if (!isMirrorDebug()) return null
+  return <MirrorDevPanelInner />
+}
+
+function MirrorDevPanelInner(): JSX.Element {
+  const { enabled, status, computers, loading, error, notLinked, lastUpdated, refresh } = useAccount()
+  const { selectedComputerId, selectionMode, selectComputer, presenceOf } = useComputer()
+
+  return (
+    <div style={{
+      position: 'fixed', right: 12, bottom: 12, zIndex: 99999, width: 320,
+      background: 'rgba(17,17,20,0.96)', color: '#e5e7eb', border: '1px solid rgba(255,255,255,0.12)',
+      borderRadius: 12, padding: 12, font: '12px/1.4 ui-monospace, monospace',
+      boxShadow: '0 8px 30px rgba(0,0,0,0.5)',
+    }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
+        <strong style={{ fontSize: 12 }}>Mirror · Computers</strong>
+        <button
+          onClick={refresh}
+          style={{ background: 'rgba(255,255,255,0.08)', color: '#e5e7eb', border: '1px solid rgba(255,255,255,0.15)',
+                   borderRadius: 6, padding: '2px 8px', cursor: 'pointer' }}
+        >
+          {loading ? '…' : 'Refresh'}
+        </button>
+      </div>
+
+      <div style={{ opacity: 0.7, marginBottom: 8 }}>
+        flag:{enabled ? 'on' : 'off'} · linked:{status ? String(status.linked) : '?'} · mode:{selectionMode}
+        {lastUpdated ? ` · ${new Date(lastUpdated).toLocaleTimeString()}` : ''}
+      </div>
+
+      {!enabled && <div style={{ opacity: 0.7 }}>Account UX flag is off — set localStorage.homepilot_accounts_ux=1</div>}
+      {enabled && notLinked && <div style={{ opacity: 0.8 }}>No cloud account linked yet.</div>}
+      {enabled && error && <div style={{ color: '#f87171' }}>Error: {error}</div>}
+      {enabled && !notLinked && !error && computers.length === 0 && !loading && (
+        <div style={{ opacity: 0.7 }}>No computers found.</div>
+      )}
+
+      <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+        {computers.map((c) => {
+          const state: PresenceState = presenceOf(c.node_id)
+          const selected = c.node_id === selectedComputerId
+          return (
+            <li
+              key={c.node_id}
+              onClick={() => selectComputer(selected ? null : c.node_id)}
+              title={c.node_id}
+              style={{
+                display: 'flex', alignItems: 'center', gap: 8, padding: '6px 8px', cursor: 'pointer',
+                borderRadius: 8, marginTop: 4,
+                background: selected ? 'rgba(139,92,246,0.18)' : 'rgba(255,255,255,0.03)',
+                border: selected ? '1px solid rgba(139,92,246,0.5)' : '1px solid transparent',
+              }}
+            >
+              <span style={{ width: 8, height: 8, borderRadius: '50%', background: DOT[state], flex: '0 0 auto' }} />
+              <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {c.node_name || c.node_id}
+              </span>
+              <span style={{ opacity: 0.6 }}>{c.platform || '—'}</span>
+              <span style={{ opacity: 0.6 }}>{state}</span>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}

--- a/frontend/src/ui/account/RemoteOfflineBanner.tsx
+++ b/frontend/src/ui/account/RemoteOfflineBanner.tsx
@@ -1,0 +1,94 @@
+/**
+ * RemoteOfflineBanner (Batch 6) — honest offline state.
+ *
+ * When the user has PINNED a specific computer that is offline, this shows a
+ * persistent banner ("Studio PC is offline — turn it on to continue") with
+ * Troubleshoot / Notify actions. Combined with the send guard in App
+ * (sendTextOrIntent), it guarantees no silent Web-CPU downgrade for a pinned
+ * selection.
+ *
+ * ADDITIVE and self-contained: renders null unless a pinned computer is
+ * offline, so mounting it changes nothing by default. It also briefly pulses
+ * when a blocked send fires the `homepilot:remote-offline-nudge` event.
+ */
+import React, { useEffect, useState } from 'react'
+import { AlertTriangle, Bell, BellRing, Wrench, X } from 'lucide-react'
+
+import { useComputer } from './ComputerContext'
+import { useSelectedOfflineNode } from './useRemoteChatTarget'
+
+export function RemoteOfflineBanner(): JSX.Element | null {
+  const offline = useSelectedOfflineNode()
+  const { selectComputer } = useComputer()
+  const [pulse, setPulse] = useState(false)
+  const [notified, setNotified] = useState(false)
+  const [dismissed, setDismissed] = useState(false)
+
+  // Reset transient UI when the offline node changes (e.g. it came back online).
+  useEffect(() => {
+    setDismissed(false)
+    setNotified(false)
+  }, [offline?.nodeId])
+
+  // Flash when a send is blocked so the user connects the dots.
+  useEffect(() => {
+    const onNudge = () => {
+      setDismissed(false)
+      setPulse(true)
+      window.setTimeout(() => setPulse(false), 1400)
+    }
+    window.addEventListener('homepilot:remote-offline-nudge', onNudge)
+    return () => window.removeEventListener('homepilot:remote-offline-nudge', onNudge)
+  }, [])
+
+  if (!offline || dismissed) return null
+
+  const openSettings = () =>
+    window.dispatchEvent(new CustomEvent('homepilot:open-settings', { detail: { section: 'account' } }))
+
+  return (
+    <div className="fixed top-3 left-1/2 -translate-x-1/2 z-[120] w-[min(560px,calc(100vw-2rem))]">
+      <div
+        className={[
+          'rounded-2xl border px-4 py-3 flex items-start gap-3 shadow-2xl backdrop-blur',
+          'bg-amber-500/[0.12] border-amber-400/30 text-amber-100',
+          pulse ? 'ring-2 ring-amber-400/70 animate-pulse' : '',
+        ].join(' ')}
+        role="status"
+      >
+        <AlertTriangle size={18} className="text-amber-300 shrink-0 mt-0.5" />
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-medium">{offline.nodeName} is offline</div>
+          <div className="text-[12px] text-amber-100/70">
+            This chat is set to run on {offline.nodeName}. Turn that computer on to continue —
+            HomePilot won't silently run it here.
+          </div>
+          <div className="flex items-center gap-2 mt-2">
+            <button
+              onClick={openSettings}
+              className="text-[11px] px-2.5 py-1 rounded-lg bg-white/10 hover:bg-white/20 border border-white/15 inline-flex items-center gap-1"
+            >
+              <Wrench size={12} /> Troubleshoot
+            </button>
+            <button
+              onClick={() => setNotified(true)}
+              disabled={notified}
+              className="text-[11px] px-2.5 py-1 rounded-lg bg-white/10 hover:bg-white/20 border border-white/15 inline-flex items-center gap-1 disabled:opacity-70"
+            >
+              {notified ? <><BellRing size={12} /> We'll notify you</> : <><Bell size={12} /> Notify me when online</>}
+            </button>
+            <button
+              onClick={() => selectComputer(null)}
+              className="text-[11px] px-2.5 py-1 rounded-lg text-amber-100/70 hover:text-amber-100"
+            >
+              Use Automatic
+            </button>
+          </div>
+        </div>
+        <button onClick={() => setDismissed(true)} className="text-amber-100/50 hover:text-amber-100 shrink-0" aria-label="Dismiss">
+          <X size={15} />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/ui/account/RemoteProjects.tsx
+++ b/frontend/src/ui/account/RemoteProjects.tsx
@@ -1,0 +1,117 @@
+/**
+ * RemoteProjects (Batch 9) — projects stored on your other computers.
+ *
+ * Lists each online node's projects (mirror `projects.list`) with a
+ * "Stored on Studio PC" badge, honest offline state (Batch 6), and an Open
+ * action that selects that computer so chat runs on it (Batch 5). Read-only
+ * over existing whitelisted RPC — NO project data is copied to the cloud.
+ *
+ * ADDITIVE and flag-gated: renders null when the Account & Computers flag is
+ * off, so the Projects page is unchanged by default.
+ */
+import React, { useEffect, useMemo, useState } from 'react'
+import { FolderKanban, RefreshCw } from 'lucide-react'
+
+import { isAccountsUxEnabled } from './featureFlags'
+import { useAccount } from './HomePilotAccountProvider'
+import { useComputer } from './ComputerContext'
+import { MirrorError, mirrorClient } from './mirrorClient'
+
+interface RemoteProject { id?: string; name?: string; project_type?: string }
+interface Row { hpuri: string; nodeId: string; nodeName: string; online: boolean; id: string; name: string; type: string }
+
+export function RemoteProjects(): JSX.Element | null {
+  if (!isAccountsUxEnabled()) return null
+  return <RemoteProjectsInner />
+}
+
+function RemoteProjectsInner(): JSX.Element | null {
+  const { computers, loading, refresh } = useAccount()
+  const { selectComputer } = useComputer()
+  const [byNode, setByNode] = useState<Record<string, RemoteProject[] | null>>({})
+
+  useEffect(() => {
+    let cancelled = false
+    computers.filter((c) => c.online && byNode[c.node_id] === undefined).forEach(async (c) => {
+      try {
+        const list = await mirrorClient.rpc<RemoteProject[]>(c.node_id, 'projects.list', {})
+        if (!cancelled) setByNode((p) => ({ ...p, [c.node_id]: Array.isArray(list) ? list : [] }))
+      } catch (e) {
+        if (!(e instanceof MirrorError && e.isNodeOffline) && !cancelled) {
+          setByNode((p) => ({ ...p, [c.node_id]: null }))
+        }
+      }
+    })
+    return () => { cancelled = true }
+  }, [computers, byNode])
+
+  const rows = useMemo<Row[]>(() => {
+    const out: Row[] = []
+    for (const c of computers) {
+      for (const p of byNode[c.node_id] || []) {
+        if (!p.id) continue
+        out.push({
+          hpuri: `hpnode://${c.node_id}/project/${p.id}`,
+          nodeId: c.node_id, nodeName: c.node_name || c.node_id, online: c.online,
+          id: p.id, name: p.name || p.id, type: p.project_type || 'project',
+        })
+      }
+    }
+    return out
+  }, [computers, byNode])
+
+  const openRemote = (r: Row) => {
+    // Open = run on the owning computer. Select it (Batch-5 routes chat there)
+    // and remember the project context. No cloud copy is made.
+    selectComputer(r.nodeId)
+    try { localStorage.setItem('homepilot_current_project', r.id) } catch { /* ignore */ }
+    window.dispatchEvent(new CustomEvent('homepilot:open-remote-project', {
+      detail: { nodeId: r.nodeId, projectId: r.id },
+    }))
+  }
+
+  // Nothing to show unless at least one computer exists.
+  if (computers.length === 0) return null
+
+  return (
+    <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4 mb-4">
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <FolderKanban size={16} className="text-white/60" />
+          <h3 className="text-sm font-semibold text-white/80">Projects on your computers</h3>
+        </div>
+        <button onClick={refresh} className="text-[11px] px-2.5 py-1 rounded-lg bg-white/5 hover:bg-white/10 border border-white/10 text-white/60 inline-flex items-center gap-1">
+          <RefreshCw size={12} className={loading ? 'animate-spin' : ''} /> Refresh
+        </button>
+      </div>
+
+      {/* Offline computers: honest state, never a silent downgrade. */}
+      {computers.filter((c) => !c.online).map((c) => (
+        <div key={c.node_id} className="text-[11px] text-amber-200/70 mb-1.5">
+          {c.node_name || c.node_id} is offline — its projects are available when you turn it on.
+        </div>
+      ))}
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+        {rows.map((r) => (
+          <button
+            key={r.hpuri}
+            onClick={() => openRemote(r)}
+            disabled={!r.online}
+            className="text-left rounded-xl border border-white/10 bg-white/[0.02] hover:bg-white/[0.05] px-3 py-2.5 disabled:opacity-50"
+          >
+            <div className="text-[13px] text-white/90 truncate">{r.name}</div>
+            <div className="text-[10px] text-white/45 capitalize">
+              {r.type} · Stored on {r.nodeName}{r.online ? '' : ' · offline'}
+            </div>
+          </button>
+        ))}
+      </div>
+      {rows.length === 0 && (
+        <div className="text-xs text-white/45 py-3 text-center">
+          {loading ? 'Loading…' : 'No projects found on your online computers.'}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/ui/account/UnifiedModelCatalog.tsx
+++ b/frontend/src/ui/account/UnifiedModelCatalog.tsx
@@ -1,0 +1,157 @@
+/**
+ * UnifiedModelCatalog (Batch 8) — one catalog of the models on your computers.
+ *
+ * Presents the chat/image/video models advertised by each linked node
+ * (mirror `models.list`) as a single list with source badges
+ * ("Installed on Studio PC"), keyed by canonical `hpnode://<node>/model/<id>`
+ * identifiers so identically-named models on different computers never collide.
+ *
+ * "Use for chat" selects that computer + model, so Batch-5 routing runs the
+ * completion there — no manual provider setup. Pure presentation over existing
+ * RPC; ADDITIVE and flag-gated. Renders null when the flag is off.
+ */
+import React, { useEffect, useMemo, useState } from 'react'
+import { Boxes, Check, Cpu, RefreshCw } from 'lucide-react'
+
+import { isAccountsUxEnabled } from './featureFlags'
+import { useAccount } from './HomePilotAccountProvider'
+import { useComputer } from './ComputerContext'
+import { MirrorError, mirrorClient } from './mirrorClient'
+import type { MirrorNode } from './types'
+
+interface ModelEntry { id?: string; display_name?: string; status?: string }
+interface ModelsList { chat_models?: ModelEntry[]; image_models?: ModelEntry[]; video_models?: ModelEntry[] }
+type Kind = 'chat' | 'image' | 'video'
+
+interface Row {
+  hpuri: string
+  nodeId: string
+  nodeName: string
+  online: boolean
+  kind: Kind
+  id: string
+  label: string
+}
+
+function modelIds(list: ModelsList | null | undefined, key: keyof ModelsList): ModelEntry[] {
+  const arr = list?.[key]
+  return Array.isArray(arr) ? arr : []
+}
+
+export function UnifiedModelCatalog(): JSX.Element | null {
+  if (!isAccountsUxEnabled()) return null
+  return <UnifiedModelCatalogInner />
+}
+
+function UnifiedModelCatalogInner(): JSX.Element {
+  const { computers, loading, refresh } = useAccount()
+  const { selectComputer, selectedComputerId } = useComputer()
+  const [byNode, setByNode] = useState<Record<string, ModelsList | null>>({})
+  const [filter, setFilter] = useState<Kind>('chat')
+  const [activeModel, setActiveModel] = useState<string>(() => {
+    try { return localStorage.getItem('homepilot_model_chat') || '' } catch { return '' }
+  })
+
+  // Fetch models.list for each online node (cached; offline nodes skipped).
+  useEffect(() => {
+    let cancelled = false
+    computers.filter((c) => c.online && byNode[c.node_id] === undefined).forEach(async (c) => {
+      try {
+        const list = await mirrorClient.rpc<ModelsList>(c.node_id, 'models.list', {})
+        if (!cancelled) setByNode((p) => ({ ...p, [c.node_id]: list }))
+      } catch (e) {
+        if (!(e instanceof MirrorError && e.isNodeOffline) && !cancelled) {
+          setByNode((p) => ({ ...p, [c.node_id]: null }))
+        }
+      }
+    })
+    return () => { cancelled = true }
+  }, [computers, byNode])
+
+  const rows = useMemo<Row[]>(() => {
+    const out: Row[] = []
+    const keyFor: Record<Kind, keyof ModelsList> = { chat: 'chat_models', image: 'image_models', video: 'video_models' }
+    for (const c of computers as MirrorNode[]) {
+      const list = byNode[c.node_id]
+      for (const entry of modelIds(list, keyFor[filter])) {
+        const id = entry.id
+        if (!id) continue
+        out.push({
+          hpuri: `hpnode://${c.node_id}/model/${id}`,
+          nodeId: c.node_id,
+          nodeName: c.node_name || c.node_id,
+          online: c.online,
+          kind: filter,
+          id,
+          label: entry.display_name || id,
+        })
+      }
+    }
+    return out
+  }, [computers, byNode, filter])
+
+  const useForChat = (r: Row) => {
+    selectComputer(r.nodeId)                 // Batch-5 routes chat to this node
+    try { localStorage.setItem('homepilot_model_chat', r.id) } catch { /* ignore */ }
+    setActiveModel(r.id)
+  }
+
+  return (
+    <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4 mb-4">
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <Boxes size={16} className="text-white/60" />
+          <h3 className="text-sm font-semibold text-white/80">Models on your computers</h3>
+        </div>
+        <button onClick={refresh} className="text-[11px] px-2.5 py-1 rounded-lg bg-white/5 hover:bg-white/10 border border-white/10 text-white/60 inline-flex items-center gap-1">
+          <RefreshCw size={12} className={loading ? 'animate-spin' : ''} /> Refresh
+        </button>
+      </div>
+
+      <div className="flex gap-1.5 mb-3">
+        {(['chat', 'image', 'video'] as Kind[]).map((k) => (
+          <button
+            key={k}
+            onClick={() => setFilter(k)}
+            className={`text-[11px] px-2.5 py-1 rounded-full border ${filter === k ? 'bg-violet-500/15 border-violet-400/40 text-white' : 'bg-white/[0.02] border-white/10 text-white/50 hover:text-white/80'}`}
+          >
+            {k[0].toUpperCase() + k.slice(1)}
+          </button>
+        ))}
+      </div>
+
+      <div className="space-y-1.5 max-h-72 overflow-y-auto">
+        {rows.map((r) => {
+          const active = r.kind === 'chat' && r.id === activeModel && r.nodeId === selectedComputerId
+          return (
+            <div key={r.hpuri} className="flex items-center gap-3 rounded-xl border border-white/10 bg-white/[0.02] px-3 py-2">
+              <Cpu size={14} className="text-white/40 shrink-0" />
+              <div className="min-w-0 flex-1">
+                <div className="text-[13px] text-white/90 truncate">{r.label}</div>
+                <div className="text-[10px] text-white/45">
+                  Installed on {r.nodeName}{r.online ? '' : ' · offline'}
+                </div>
+              </div>
+              {r.kind === 'chat' ? (
+                <button
+                  onClick={() => useForChat(r)}
+                  disabled={!r.online}
+                  className={`text-[11px] px-2.5 py-1 rounded-lg border inline-flex items-center gap-1 disabled:opacity-40 ${active ? 'bg-emerald-500/15 border-emerald-400/40 text-emerald-200' : 'bg-white/5 border-white/10 text-white/70 hover:bg-white/10'}`}
+                >
+                  {active ? <><Check size={12} /> Active</> : 'Use for chat'}
+                </button>
+              ) : (
+                <span className="text-[10px] text-white/40">on {r.nodeName}</span>
+              )}
+            </div>
+          )
+        })}
+        {rows.length === 0 && (
+          <div className="text-xs text-white/45 py-4 text-center">
+            {loading ? 'Loading…' : 'No models advertised by your online computers.'}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/ui/account/featureFlags.ts
+++ b/frontend/src/ui/account/featureFlags.ts
@@ -1,0 +1,62 @@
+/**
+ * Feature flags for the Account & Computers spine (Batch 2).
+ *
+ * Everything here is OFF by default so mounting the providers is a no-op until
+ * explicitly enabled — the spine must never change today's behavior.
+ */
+
+function lsGet(key: string): string | null {
+  try {
+    return typeof localStorage !== 'undefined' ? localStorage.getItem(key) : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Master switch for the Account & Computers experience. Enable via a build-time
+ * env (`VITE_ACCOUNTS_UX=1`) or at runtime (`localStorage.homepilot_accounts_ux = '1'`).
+ * When false the providers render children but do no network and hold empty state.
+ */
+export function isAccountsUxEnabled(): boolean {
+  try {
+    const env = (import.meta as unknown as { env?: Record<string, string> }).env?.VITE_ACCOUNTS_UX
+    if (env === '1' || env === 'true') return true
+  } catch {
+    /* import.meta not available (e.g. tests) */
+  }
+  return lsGet('homepilot_accounts_ux') === '1'
+}
+
+/**
+ * BFF session (Batch 7). When on, the browser stops storing/sending the cloud
+ * token — the HomePilot Web backend holds it server-side (keyed to the session)
+ * and injects it into cloud-relay calls. Enable via `VITE_BFF_SESSION=1` or
+ * `localStorage.homepilot_bff_session = '1'`. Must be paired with the backend
+ * flag HOMEPILOT_BFF_SESSION_ENABLED. Off by default (strangler).
+ */
+export function isBffSessionEnabled(): boolean {
+  try {
+    const env = (import.meta as unknown as { env?: Record<string, string> }).env?.VITE_BFF_SESSION
+    if (env === '1' || env === 'true') return true
+  } catch {
+    /* import.meta not available */
+  }
+  return lsGet('homepilot_bff_session') === '1'
+}
+
+/**
+ * Dev-only visibility for the mirror debug panel. Enable with `?mirrorDebug=1`
+ * in the URL or `localStorage.homepilot_mirror_debug = '1'`.
+ */
+export function isMirrorDebug(): boolean {
+  try {
+    if (typeof location !== 'undefined') {
+      const q = new URLSearchParams(location.search).get('mirrorDebug')
+      if (q === '1' || q === 'true') return true
+    }
+  } catch {
+    /* no location */
+  }
+  return lsGet('homepilot_mirror_debug') === '1'
+}

--- a/frontend/src/ui/account/mirrorClient.ts
+++ b/frontend/src/ui/account/mirrorClient.ts
@@ -1,0 +1,123 @@
+/**
+ * MirrorClient — the single typed entry point to the cloud mirror, via the
+ * HomePilot Web BFF (Batch 1) at ``/v1/account/mirror/*``.
+ *
+ * It calls ONLY the same-origin BFF routes with the existing HomePilot auth
+ * token. It never constructs a cloud relay URL and never touches a cloud token
+ * — that stays server-side (design §11: "Do not let individual UI components
+ * construct cloud relay URLs or read cloud tokens.").
+ */
+import { resolveBackendUrl } from '../lib/backendUrl'
+import type { MirrorNode, MirrorStatus, NodeManifest } from './types'
+
+const LS_TOKEN_KEY = 'homepilot_auth_token'
+
+/** Error that preserves the BFF/upstream status so callers can branch on it
+ *  (e.g. 409 → node_offline, 503 → cloud not linked). */
+export class MirrorError extends Error {
+  status: number
+  code?: string
+  body?: unknown
+  constructor(status: number, body: unknown) {
+    const b = (body ?? {}) as { error?: string; message?: string }
+    super(b.message || b.error || `Mirror request failed (${status})`)
+    this.name = 'MirrorError'
+    this.status = status
+    this.code = b.error
+    this.body = body
+  }
+  /** The owning computer is offline (honest offline signal, design §8). */
+  get isNodeOffline(): boolean {
+    return this.status === 409 && this.code === 'node_offline'
+  }
+  /** No server-side cloud credential is available for this account yet. */
+  get isNotLinked(): boolean {
+    return this.status === 503
+  }
+}
+
+function authHeaders(): Record<string, string> {
+  const h: Record<string, string> = { 'Content-Type': 'application/json' }
+  try {
+    const tok = localStorage.getItem(LS_TOKEN_KEY) || ''
+    if (tok) h['Authorization'] = `Bearer ${tok}`
+  } catch {
+    /* storage unavailable */
+  }
+  return h
+}
+
+async function safeJson(res: Response): Promise<unknown> {
+  try {
+    return await res.json()
+  } catch {
+    return null
+  }
+}
+
+async function request<T>(
+  method: string,
+  path: string,
+  opts: { body?: unknown; signal?: AbortSignal } = {},
+): Promise<T> {
+  const base = resolveBackendUrl()
+  const res = await fetch(`${base}/v1/account/mirror${path}`, {
+    method,
+    headers: authHeaders(),
+    body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+    signal: opts.signal,
+    // BFF is same-origin in the web deployment; include cookies so the
+    // homepilot_session cookie authenticates even without a Bearer token.
+    credentials: 'include',
+  })
+  if (!res.ok) {
+    throw new MirrorError(res.status, await safeJson(res))
+  }
+  return (await res.json()) as T
+}
+
+const enc = encodeURIComponent
+
+export const mirrorClient = {
+  /** Is the feature usable and is a cloud credential linked server-side? */
+  status(signal?: AbortSignal): Promise<MirrorStatus> {
+    return request<MirrorStatus>('GET', '/status', { signal })
+  },
+
+  /** The account's computers with live online state. */
+  listNodes(signal?: AbortSignal): Promise<MirrorNode[]> {
+    return request<MirrorNode[]>('GET', '/nodes', { signal })
+  },
+
+  /** A node's full manifest (GPU/VRAM/models/projects/capabilities). */
+  getManifest(nodeId: string, signal?: AbortSignal): Promise<NodeManifest> {
+    return request<NodeManifest>('GET', `/nodes/${enc(nodeId)}/manifest`, { signal })
+  },
+
+  /** Invoke one read-only, allow-listed RPC operation on a node. */
+  rpc<T = unknown>(nodeId: string, operation: string, params: Record<string, unknown> = {}): Promise<T> {
+    return request<T>('POST', `/nodes/${enc(nodeId)}/rpc`, { body: { operation, params } })
+  },
+
+  /** Create a durable job (chat/image/video) on a node. */
+  createJob<T = unknown>(
+    nodeId: string,
+    operation: string,
+    params: Record<string, unknown> = {},
+    resourceUri?: string,
+  ): Promise<T> {
+    return request<T>('POST', `/nodes/${enc(nodeId)}/jobs`, {
+      body: { operation, params, ...(resourceUri ? { resource_uri: resourceUri } : {}) },
+    })
+  },
+
+  getJob<T = unknown>(jobId: string, nodeId: string): Promise<T> {
+    return request<T>('GET', `/jobs/${enc(jobId)}?node_id=${enc(nodeId)}`)
+  },
+
+  cancelJob<T = unknown>(jobId: string, nodeId: string): Promise<T> {
+    return request<T>('POST', `/jobs/${enc(jobId)}/cancel?node_id=${enc(nodeId)}`)
+  },
+}
+
+export type MirrorClient = typeof mirrorClient

--- a/frontend/src/ui/account/types.ts
+++ b/frontend/src/ui/account/types.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared types for the Account & Computers spine (Batch 2).
+ *
+ * These mirror the OllaBridge Cloud mirror contract as surfaced by the
+ * HomePilot Web BFF at ``/v1/account/mirror/*`` (Batch 1). The node list is
+ * intentionally lean; richer detail (GPU/VRAM/models/projects/capabilities)
+ * comes from a node's manifest, fetched lazily.
+ */
+
+/** One computer linked to the account, from ``GET /v1/account/mirror/nodes``. */
+export interface MirrorNode {
+  node_id: string
+  node_name: string
+  platform?: string | null
+  online: boolean
+}
+
+/**
+ * A node's manifest, relayed from the owning machine. Loosely typed because the
+ * schema is owned by HomePilot Local; a few commonly-present fields are called
+ * out for convenience, everything else is passed through.
+ */
+export interface NodeManifest {
+  gpu?: { name?: string; vram_mb?: number } | null
+  os?: string | null
+  models?: unknown[]
+  projects?: unknown[]
+  capabilities?: string[]
+  revision?: string | number
+  [key: string]: unknown
+}
+
+/** Readiness probe from ``GET /v1/account/mirror/status``. */
+export interface MirrorStatus {
+  ok: boolean
+  enabled: boolean
+  linked: boolean
+  cloud?: string
+}
+
+/** Where the user wants AI work to run. */
+export type SelectionMode = 'automatic' | 'fixed' | 'ask'
+
+/** Coarse presence state used by status indicators (design §8). */
+export type PresenceState = 'online' | 'offline' | 'attention' | 'unknown'

--- a/frontend/src/ui/account/useRemoteChatTarget.ts
+++ b/frontend/src/ui/account/useRemoteChatTarget.ts
@@ -1,0 +1,104 @@
+/**
+ * useRemoteChatTarget (Batch 5) — resolve where a chat completion should run.
+ *
+ * When the Account & Computers flag is on and the user has picked an ONLINE
+ * remote computer (fixed selection), this returns the cloud-relay target for
+ * that node's chat model — the SAME mechanism "Use for Chat" uses
+ * (openai_compat @ {cloud}/ollama/v1, routed by model). Returns null in every
+ * other case, so the local chat path is used unchanged.
+ *
+ * It only RESOLVES a target; the actual conditional swap happens in App's
+ * `currentChatSelection()`. No execution, persistence, or provider mutation here.
+ */
+import { useEffect, useState } from 'react'
+
+import { useAccount } from './HomePilotAccountProvider'
+import { useComputer } from './ComputerContext'
+import { mirrorClient } from './mirrorClient'
+import type { MirrorStatus } from './types'
+
+function cloudBase(status: MirrorStatus | null): string {
+  try {
+    const ls = localStorage.getItem('homepilot_cloud_url')
+    if (ls) return ls.replace(/\/+$/, '')
+  } catch { /* ignore */ }
+  return (status?.cloud || '').replace(/\/+$/, '')
+}
+
+function currentModelChat(): string {
+  try { return localStorage.getItem('homepilot_model_chat') || '' } catch { return '' }
+}
+
+interface ModelsListResult { chat_models?: Array<{ id?: string } | string> }
+
+function pickChatModel(list: ModelsListResult | null, preferred: string): string {
+  const ids: string[] = []
+  for (const m of list?.chat_models || []) {
+    const id = typeof m === 'string' ? m : m?.id
+    if (id) ids.push(id)
+  }
+  if (preferred && ids.includes(preferred)) return preferred
+  return ids[0] || ''
+}
+
+export interface RemoteChatTarget {
+  baseUrl: string
+  model: string
+  nodeId: string
+  nodeName: string
+}
+
+export function useRemoteChatTarget(): RemoteChatTarget | null {
+  const { enabled, status } = useAccount()
+  const { selectedComputer, selectionMode, presenceOf } = useComputer()
+  const [model, setModel] = useState('')
+
+  const nodeId = selectedComputer?.node_id || ''
+  const online = nodeId ? presenceOf(nodeId) === 'online' : false
+  // Only hijack routing on an explicit, online, fixed pick — never in automatic.
+  const active = enabled && selectionMode === 'fixed' && !!nodeId && online
+
+  useEffect(() => {
+    if (!active || !nodeId) { setModel(''); return }
+    let cancelled = false
+    ;(async () => {
+      try {
+        const list = await mirrorClient.rpc<ModelsListResult>(nodeId, 'models.list', {})
+        if (!cancelled) setModel(pickChatModel(list, currentModelChat()))
+      } catch {
+        // Relay routes by model name — fall back to the current chat model.
+        if (!cancelled) setModel(currentModelChat())
+      }
+    })()
+    return () => { cancelled = true }
+  }, [active, nodeId])
+
+  if (!active || !selectedComputer) return null
+  const cloud = cloudBase(status)
+  const resolved = model || currentModelChat()
+  if (!cloud || !resolved) return null
+  return {
+    baseUrl: `${cloud}/ollama/v1`,
+    model: resolved,
+    nodeId,
+    nodeName: selectedComputer.node_name || nodeId,
+  }
+}
+
+/**
+ * Batch 6: honest offline. When the user has PINNED a specific computer (fixed
+ * selection) that is currently offline, return its identity so the UI can show
+ * an offline state and BLOCK sends — never silently downgrade to Web CPU.
+ * Returns null in automatic mode (which may pick another online computer) and
+ * whenever the pinned computer is online.
+ */
+export function useSelectedOfflineNode(): { nodeId: string; nodeName: string } | null {
+  const { enabled } = useAccount()
+  const { selectedComputer, selectionMode, presenceOf } = useComputer()
+  if (!enabled || selectionMode !== 'fixed' || !selectedComputer) return null
+  if (presenceOf(selectedComputer.node_id) === 'online') return null
+  return {
+    nodeId: selectedComputer.node_id,
+    nodeName: selectedComputer.node_name || selectedComputer.node_id,
+  }
+}

--- a/frontend/src/ui/components/AuthScreen.tsx
+++ b/frontend/src/ui/components/AuthScreen.tsx
@@ -22,6 +22,7 @@
  * so nothing leaks into the rest of the app.
  */
 import React, { useEffect, useRef, useState } from 'react'
+import { isBffSessionEnabled } from '../account/featureFlags'
 import type { AuthUser, RecentUser } from './AuthGate'
 
 interface AuthScreenProps {
@@ -229,7 +230,10 @@ export default function AuthScreen({
       // Models tab uses it to sync models from the user's linked GPU nodes
       // and to route inference through the relay to their own machine.
       try {
-        localStorage.setItem('homepilot_cloud_token', loginData.token)
+        // Batch 7 (BFF): when the backend holds the cloud token server-side we
+        // no longer persist it in the browser — the exchange POST below still
+        // hands it to the backend. The (non-secret) cloud URL is kept.
+        if (!isBffSessionEnabled()) localStorage.setItem('homepilot_cloud_token', loginData.token)
         localStorage.setItem('homepilot_cloud_url', cloudUrl)
       } catch { /* ignore */ }
       // 2) Exchange the Cloud token for a local HomePilot session (JIT-provision).

--- a/frontend/src/ui/components/OllaBridgeLink.tsx
+++ b/frontend/src/ui/components/OllaBridgeLink.tsx
@@ -20,6 +20,7 @@
  * the Cloud directly (CORS open), stores only the token in localStorage.
  */
 import React, { useCallback, useEffect, useState } from 'react'
+import { isBffSessionEnabled } from '../account/featureFlags'
 import { Cloud, Cpu, Download, ExternalLink, Loader2, LogOut, MonitorSmartphone, Plus, RefreshCw, Server, ShieldCheck } from 'lucide-react'
 import { getCloudToken, getCloudUrl } from './OllaBridgeModels'
 import { getEdition, type EditionInfo } from '../lib/edition'
@@ -114,7 +115,9 @@ export default function OllaBridgeLink() {
       const data = await r.json().catch(() => ({}))
       if (!r.ok || !data.token) { setError(data.detail || 'Invalid OllaBridge email or password'); return }
       try {
-        localStorage.setItem('homepilot_cloud_token', data.token)
+        // Batch 7 (BFF): don't persist the cloud token in the browser when the
+        // backend holds it server-side. The cloud URL (non-secret) is kept.
+        if (!isBffSessionEnabled()) localStorage.setItem('homepilot_cloud_token', data.token)
         localStorage.setItem('homepilot_cloud_url', cloudUrl)
       } catch { /* ignore */ }
       setToken(data.token); setPw('')

--- a/frontend/src/ui/components/OllaBridgeModels.tsx
+++ b/frontend/src/ui/components/OllaBridgeModels.tsx
@@ -22,6 +22,7 @@
  * zero prop-drilling into the existing Models plumbing.
  */
 import React, { useCallback, useEffect, useState } from 'react'
+import { isBffSessionEnabled } from '../account/featureFlags'
 import { Cloud, Cpu, Loader2, LogOut, RefreshCw, Zap } from 'lucide-react'
 
 const LS_CLOUD_TOKEN = 'homepilot_cloud_token'
@@ -152,7 +153,9 @@ export default function OllaBridgeModels({ filterType }: { filterType?: string }
         return
       }
       try {
-        localStorage.setItem(LS_CLOUD_TOKEN, data.token)
+        // Batch 7 (BFF): the token lives in this component's memory for the
+        // session; when BFF is on we no longer persist it in browser storage.
+        if (!isBffSessionEnabled()) localStorage.setItem(LS_CLOUD_TOKEN, data.token)
         localStorage.setItem(LS_CLOUD_URL, cloudUrl)
       } catch { /* ignore */ }
       setToken(data.token)


### PR DESCRIPTION
Both are pure presentation over the existing mirror RPC, self-gated on the
Account & Computers flag (render null when off) — the Models page, Providers
section, and Projects page are byte-for-byte unchanged by default.

Batch 8 — Unified model catalog:
- account/UnifiedModelCatalog.tsx: one list of the chat/image/video models
  each linked node advertises (mirror models.list), with "Installed on <node>"
  source badges and canonical hpnode://<node>/model/<id> keys so same-named
  models on different computers don't collide. "Use for chat" selects that
  computer + model so Batch-5 routing runs it there. Chat/image/video filter;
  offline nodes shown but disabled.
- Mounted at the top of Settings → Models. The OllaBridge provider is relocated
  under Settings → Providers when the flag is on (and hidden from the primary
  Models tab in Models.tsx) — no longer a user-facing provider.

Batch 9 — Remote projects (read):
- account/RemoteProjects.tsx: lists each online node's projects
  (mirror projects.list, already whitelisted) with "Stored on <node>" badges
  and honest offline state (Batch 6). Open selects the owning computer (chat
  then runs there via Batch 5) and records project context — NO project data is
  copied to the cloud. Mounted at the top of the Projects "My Projects" tab.