### PR TITLE
Point OllaBridge cloud default at app.ollabridge.com

### DIFF
--- a/frontend/src/ui/components/AuthScreen.tsx
+++ b/frontend/src/ui/components/AuthScreen.tsx
@@ -39,7 +39,7 @@ function getCloudUrl(): string {
   const env: Record<string, string | undefined> =
     ((import.meta as unknown as { env?: Record<string, string | undefined> }).env) || {}
   const v = (env.VITE_OLLABRIDGE_CLOUD_URL || '').trim()
-  return (v || 'https://ruslanmv-ollabridge.hf.space').replace(/\/+$/, '')
+  return (v || 'https://app.ollabridge.com').replace(/\/+$/, '')
 }
 
 export default function AuthScreen({

--- a/frontend/src/ui/components/OllaBridgeModels.tsx
+++ b/frontend/src/ui/components/OllaBridgeModels.tsx
@@ -30,12 +30,23 @@ const LS_CLOUD_URL = 'homepilot_cloud_url'
 
 export function getCloudUrl(): string {
   try {
-    const saved = (localStorage.getItem(LS_CLOUD_URL) || '').trim()
-    if (saved) return saved.replace(/\/+$/, '')
+    const saved = (localStorage.getItem(LS_CLOUD_URL) || '').trim().replace(/\/+$/, '')
+    // Drop known-obsolete cloud URLs so the new default/env value takes over,
+    // while preserving an intentional self-hosted URL. The raw Hugging Face
+    // origin is superseded by the branded app.ollabridge.com host.
+    const legacyUrls = new Set([
+      'https://ruslanmv-ollabridge.hf.space',
+      'https://ruslanmv-ollabridge-cloud.hf.space',
+    ])
+    if (saved && legacyUrls.has(saved)) {
+      localStorage.removeItem(LS_CLOUD_URL)
+    } else if (saved) {
+      return saved
+    }
   } catch { /* ignore */ }
   const env: Record<string, string | undefined> =
     ((import.meta as unknown as { env?: Record<string, string | undefined> }).env) || {}
-  return ((env.VITE_OLLABRIDGE_CLOUD_URL || '').trim() || 'https://ruslanmv-ollabridge.hf.space').replace(/\/+$/, '')
+  return ((env.VITE_OLLABRIDGE_CLOUD_URL || '').trim() || 'https://app.ollabridge.com').replace(/\/+$/, '')
 }
 
 export function getCloudToken(): string {


### PR DESCRIPTION
The OllaBridge Link UI (Add a machine / Pair / instructions) and the auth
calls all derive their base from getCloudUrl(), whose fallback was the raw
Hugging Face origin — so links rendered as ruslanmv-ollabridge.hf.space/link.

Minimal, additive fix (VITE_OLLABRIDGE_CLOUD_URL still overrides):
- OllaBridgeModels.getCloudUrl(): fallback -> https://app.ollabridge.com/, and
  drop known-obsolete stored cloud URLs (the raw HF origins) from localStorage
  so the new default takes effect, while preserving an intentional self-hosted
  homepilot_cloud_url.
- AuthScreen.getCloudUrl(): same fallback -> https://app.ollabridge.com/.

OllaBridgeLink imports getCloudUrl from OllaBridgeModels, so its /link and
/v1/* calls follow automatically. The apex ollabridge.com/login,link redirects
to app.ollabridge.com are handled in Vercel (out of this repo).