### PR TITLE
DayPilot bridge: §13 behavior guardrails in the propose instruction

### DIFF
--- a/backend/app/daypilot_bridge/__init__.py
+++ b/backend/app/daypilot_bridge/__init__.py
@@ -1,0 +1,35 @@
+"""DayPilot bridge — HomePilot side of the agents integration (Batch A5).
+
+DayPilot connects to HomePilot personas over the OpenAI-compatible
+``/v1/chat/completions`` API in *propose-only* mode: the persona reasons with
+its full identity/memory but must NOT perform external writes itself. Instead it
+proposes structured operations, which HomePilot returns to DayPilot in the
+``x_directives`` field. DayPilot validates every directive and routes external
+actions through its own Approval Center.
+
+This package is self-contained: it owns HomePilot's copy of the contract
+constants and does not import from DayPilot. It never mutates a persona's own
+system prompt — the propose-mode instruction is appended as a *separate* system
+message and is gone when the turn ends.
+"""
+from .bridge import (
+    BRIDGE_VERSION,
+    BridgeContext,
+    build_x_homepilot,
+    capabilities_document,
+    extract_directives,
+    identity_document,
+    parse_bridge_headers,
+    propose_system_suffix,
+)
+
+__all__ = [
+    "BRIDGE_VERSION",
+    "BridgeContext",
+    "build_x_homepilot",
+    "capabilities_document",
+    "extract_directives",
+    "identity_document",
+    "parse_bridge_headers",
+    "propose_system_suffix",
+]

--- a/backend/app/daypilot_bridge/bridge.py
+++ b/backend/app/daypilot_bridge/bridge.py
@@ -1,0 +1,314 @@
+"""DayPilot bridge protocol — header parsing, propose-mode instruction, and
+directive extraction for the OpenAI-compatible persona endpoint (Batch A5).
+
+Contract (frozen, mirrored from DayPilot's runtime contract):
+  * DayPilot sends ``X-HomePilot-Tool-Mode: propose`` on every turn.
+  * HomePilot reasons with the persona but returns *proposed* operations as
+    structured directives in ``x_directives`` — it performs no external writes.
+  * DayPilot validates each directive (type ∈ allowed set, capability ∈ allowed
+    set, argument bounds, workspace ownership) and gates external actions behind
+    its Approval Center.
+
+The persona expresses a proposal by appending a single machine block at the very
+end of its reply::
+
+    [[DAYPILOT_DIRECTIVES]]{ "directives": [ ... ] }[[/DAYPILOT_DIRECTIVES]]
+
+HomePilot parses that block, validates it defensively (the model output is
+untrusted), strips it from the visible content, and returns the directives.
+"""
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Any
+
+BRIDGE_VERSION = 1
+
+# The tool modes DayPilot may request. Only ``propose`` is ever used in
+# production; the others exist so the contract is total.
+TOOL_MODES: frozenset[str] = frozenset({"propose", "execute", "disabled"})
+DEFAULT_TOOL_MODE = "propose"
+
+# Directive types DayPilot accepts. Anything else is dropped while the plain-text
+# reply is preserved.
+ALLOWED_DIRECTIVES: frozenset[str] = frozenset(
+    {
+        "task.create",
+        "task.update",
+        "task.complete",
+        "task.block",
+        "progress.report",
+        "delegate.request",
+        "daypilot.action.propose",
+        "artifact.attach",
+    }
+)
+
+# DayPilot capabilities a ``daypilot.action.propose`` directive may target. Every
+# one of these still becomes a draft + Approval on the DayPilot side — HomePilot
+# never performs the action itself.
+CAPABILITIES: frozenset[str] = frozenset(
+    {
+        "email.send",
+        "calendar.create",
+        "calendar.update",
+        "calendar.cancel",
+        "coding.run",
+        "github.change",
+        "message.send",
+        "document.generate",
+        "finance.change",
+        "hr.change",
+        "system.change",
+    }
+)
+
+VALID_PRIORITIES: frozenset[str] = frozenset({"low", "medium", "high", "critical"})
+
+# Defensive bounds on untrusted model output (match DayPilot's validation).
+MAX_DIRECTIVES_PER_TURN = 12
+MAX_TITLE_LEN = 200
+MAX_TEXT_LEN = 4000
+
+# Sentinel-delimited machine block. Tolerant of surrounding whitespace and an
+# optional markdown code fence the model may wrap it in.
+_BLOCK_RE = re.compile(
+    r"`{0,3}\s*\[\[DAYPILOT_DIRECTIVES\]\]\s*(?P<body>.*?)\s*\[\[/DAYPILOT_DIRECTIVES\]\]\s*`{0,3}",
+    re.DOTALL,
+)
+
+
+@dataclass(frozen=True)
+class BridgeContext:
+    """Parsed state of a bridge-aware request.
+
+    ``active`` is True when DayPilot (or any bridge-aware client) is calling, so
+    the endpoint should attach ``x_directives`` / ``x_homepilot``. ``propose`` is
+    True in the only production mode: propose-only. ``session_id`` is DayPilot's
+    external session id, echoed back so DayPilot can correlate turns.
+    """
+
+    active: bool
+    tool_mode: str
+    session_id: str | None
+    bridge_version: int
+
+    @property
+    def propose(self) -> bool:
+        return self.tool_mode == "propose"
+
+
+def parse_bridge_headers(
+    *,
+    x_client_type: str | None,
+    tool_mode: str | None,
+    session_id: str | None,
+    bridge_version: str | None,
+) -> BridgeContext:
+    """Derive the bridge context from request headers.
+
+    The bridge is *active* when the caller identifies as DayPilot via
+    ``X-Client-Type: daypilot`` OR sends any explicit bridge header. An unknown
+    tool mode falls back to the safe default (propose) — HomePilot never executes
+    on DayPilot's behalf, so the conservative default is also the correct one.
+    """
+    client = (x_client_type or "").strip().lower()
+    mode_raw = (tool_mode or "").strip().lower()
+    active = client == "daypilot" or bool(mode_raw) or bool(bridge_version)
+    mode = mode_raw if mode_raw in TOOL_MODES else DEFAULT_TOOL_MODE
+    try:
+        ver = int(bridge_version) if bridge_version else BRIDGE_VERSION
+    except (TypeError, ValueError):
+        ver = BRIDGE_VERSION
+    sid = (session_id or "").strip() or None
+    return BridgeContext(active=active, tool_mode=mode, session_id=sid, bridge_version=ver)
+
+
+def propose_system_suffix() -> str:
+    """The propose-mode instruction, appended as a SEPARATE system message.
+
+    Never modifies the persona's own prompt. It tells the persona that it is
+    connected to DayPilot, cannot act on the outside world itself, and how to
+    propose an action as a machine block. On an ordinary conversational turn the
+    persona simply omits the block.
+    """
+    return (
+        "[DAYPILOT BRIDGE — propose-only mode, appended only for this turn]\n"
+        "You are connected to DayPilot, which manages the user's real tasks, "
+        "email, calendar, and projects. You CANNOT send email, change files, "
+        "schedule events, or complete tasks yourself — DayPilot does that, and "
+        "only after the user approves it.\n"
+        "Reply to the user normally. THEN, only if you intend a concrete action "
+        "or want to track work, append ONE machine block at the very end, exactly:\n"
+        "[[DAYPILOT_DIRECTIVES]]{\"directives\":[ ... ]}[[/DAYPILOT_DIRECTIVES]]\n"
+        "Each directive is an object with a \"type\". Allowed types: "
+        "task.create (title, priority, detail), task.update, task.complete, "
+        "task.block, progress.report (summary, percent), delegate.request, "
+        "artifact.attach, and daypilot.action.propose (capability + summary + "
+        "arguments) for anything that touches the outside world — capability is "
+        "one of: email.send, calendar.create, calendar.update, calendar.cancel, "
+        "message.send, document.generate, coding.run, github.change.\n"
+        "Never invent results or claim an action is done. Propose, don't perform. "
+        "If no action is needed, omit the block entirely.\n"
+        "Speak to the user in plain language: do NOT reveal raw tool calls, JSON, "
+        "function names, or the underlying model you run on, and never say a task "
+        "is complete before it actually is — DayPilot marks work complete only "
+        "after it's approved and executed."
+    )
+
+
+def _clip(value: Any, limit: int) -> str:
+    return str(value)[:limit] if value is not None else ""
+
+
+def _sanitize_directive(raw: Any) -> dict[str, Any] | None:
+    """Validate + normalize one untrusted directive. Returns None if invalid."""
+    if not isinstance(raw, dict):
+        return None
+    dtype = str(raw.get("type") or "").strip()
+    if dtype not in ALLOWED_DIRECTIVES:
+        return None
+
+    out: dict[str, Any] = {"type": dtype}
+
+    if dtype == "daypilot.action.propose":
+        capability = str(raw.get("capability") or "").strip()
+        if capability not in CAPABILITIES:
+            return None  # a real-world action with no valid capability is unusable
+        out["capability"] = capability
+        out["summary"] = _clip(raw.get("summary") or raw.get("title"), MAX_TITLE_LEN)
+        args = raw.get("arguments")
+        if isinstance(args, dict):
+            out["arguments"] = args
+
+    if "title" in raw:
+        out["title"] = _clip(raw.get("title"), MAX_TITLE_LEN)
+    if "detail" in raw or "text" in raw:
+        out["detail"] = _clip(raw.get("detail") or raw.get("text"), MAX_TEXT_LEN)
+    if "summary" in raw and "summary" not in out:
+        out["summary"] = _clip(raw.get("summary"), MAX_TITLE_LEN)
+
+    priority = str(raw.get("priority") or "").strip().lower()
+    if priority in VALID_PRIORITIES:
+        out["priority"] = priority
+
+    if "percent" in raw:
+        try:
+            out["percent"] = max(0, min(100, int(raw.get("percent"))))
+        except (TypeError, ValueError):
+            pass
+
+    # Preserve an optional client-supplied ref so DayPilot can de-duplicate.
+    if raw.get("ref"):
+        out["ref"] = _clip(raw.get("ref"), 120)
+
+    return out
+
+
+def extract_directives(content: str) -> tuple[str, list[dict[str, Any]]]:
+    """Pull the directive block out of a persona reply.
+
+    Returns ``(visible_content, directives)``. The machine block is stripped from
+    the visible content. Malformed JSON or unknown directive types are dropped
+    silently — the plain-text reply is always preserved. At most
+    ``MAX_DIRECTIVES_PER_TURN`` valid directives are returned.
+    """
+    if not content:
+        return content, []
+    match = _BLOCK_RE.search(content)
+    if not match:
+        return content, []
+
+    visible = (content[: match.start()] + content[match.end():]).strip()
+
+    directives: list[dict[str, Any]] = []
+    try:
+        parsed = json.loads(match.group("body"))
+    except (ValueError, TypeError):
+        return visible, []
+
+    items = parsed.get("directives") if isinstance(parsed, dict) else parsed
+    if not isinstance(items, list):
+        return visible, []
+
+    for raw in items:
+        clean = _sanitize_directive(raw)
+        if clean is not None:
+            directives.append(clean)
+        if len(directives) >= MAX_DIRECTIVES_PER_TURN:
+            break
+
+    return visible, directives
+
+
+def build_x_homepilot(
+    ctx: BridgeContext,
+    *,
+    project_id: str | None,
+    model: str,
+    directive_count: int,
+) -> dict[str, Any]:
+    """Bridge metadata returned alongside the OpenAI response so DayPilot can
+    correlate the turn and confirm the mode HomePilot honored."""
+    return {
+        "bridge_version": BRIDGE_VERSION,
+        "tool_mode": ctx.tool_mode,
+        "session_id": ctx.session_id,
+        "project_id": project_id,
+        "model": model,
+        "directive_count": directive_count,
+    }
+
+
+def capabilities_document() -> dict[str, Any]:
+    """Static description of what this HomePilot bridge supports, served at
+    ``/v1/integrations/daypilot/capabilities`` so DayPilot can feature-detect a
+    bridge-aware HomePilot without a chat round-trip."""
+    return {
+        "bridge_version": BRIDGE_VERSION,
+        "tool_modes": sorted(TOOL_MODES),
+        "default_tool_mode": DEFAULT_TOOL_MODE,
+        "directives": sorted(ALLOWED_DIRECTIVES),
+        "capabilities": sorted(CAPABILITIES),
+        "limits": {
+            "max_directives_per_turn": MAX_DIRECTIVES_PER_TURN,
+            "max_title_len": MAX_TITLE_LEN,
+            "max_text_len": MAX_TEXT_LEN,
+        },
+        "headers": {
+            "tool_mode": "X-HomePilot-Tool-Mode",
+            "session_id": "X-HomePilot-Session-ID",
+            "bridge_version": "X-HomePilot-Bridge-Version",
+            "client_type": "X-Client-Type",
+        },
+        "response_fields": ["x_directives", "x_homepilot"],
+        "endpoints": {"identity": "/v1/integrations/daypilot/identity"},
+        "notes": "Propose-only: HomePilot never performs external writes; DayPilot validates and approves.",
+    }
+
+
+def identity_document(
+    *,
+    account_ref: str,
+    account_label: str,
+    authenticated: bool,
+    scope: str,
+) -> dict[str, Any]:
+    """The account a DayPilot connection is bound to (multi-account security).
+
+    HomePilot has per-user accounts; the persona API can be reached with a
+    specific user's token (``scope='account'`` → this user's agents only) or with
+    the shared instance key (``scope='shared'`` → published personas, no single
+    owner). DayPilot records ``account_ref`` on the connection and stamps every
+    synced agent with it, so one user's agents can never blend with another's.
+    ``account_ref`` is a stable opaque id; no secret is ever returned.
+    """
+    return {
+        "bridge_version": BRIDGE_VERSION,
+        "account_ref": account_ref,
+        "account_label": account_label,
+        "authenticated": bool(authenticated),
+        "scope": scope,  # "account" (per-user token) | "shared" (instance key)
+    }

--- a/backend/app/openai_compat_endpoint.py
+++ b/backend/app/openai_compat_endpoint.py
@@ -24,11 +24,19 @@ import time
 import uuid
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Header
+from fastapi import APIRouter, Cookie, Depends, HTTPException, Header
 from pydantic import BaseModel, Field
 
 from .auth import require_ollabridge_api_key
 from . import config as _config
+from .daypilot_bridge import (
+    build_x_homepilot,
+    capabilities_document,
+    extract_directives,
+    identity_document,
+    parse_bridge_headers,
+    propose_system_suffix,
+)
 from .llm import chat as llm_chat, strip_think_tags
 from .personalities import registry as personality_registry, build_system_prompt, ConversationMemory
 from .storage import add_message, get_recent
@@ -309,6 +317,7 @@ async def _chat_with_persona_project(
     temperature: float,
     max_tokens: int,
     client_type: Optional[str] = None,
+    bridge_suffix: Optional[str] = None,
 ) -> str:
     """Route a chat request through a persona project, including MCP tools if enabled."""
     projects = _get_projects()
@@ -339,6 +348,12 @@ async def _chat_with_persona_project(
             "- Express emotions naturally — the avatar will reflect your mood.\n"
             "- Do not reference 'scrolling', 'clicking', or web-specific interactions."
         )
+
+    # DayPilot bridge: append the propose-only instruction as an ADDITIONAL
+    # system directive (never edits the persona's own prompt). Applies to the
+    # direct-LLM path; the agentic loop keeps its own tool policy.
+    if bridge_suffix:
+        system_prompt += "\n\n" + bridge_suffix
 
     # Extract user message and history
     user_message = messages[-1].content if messages else ""
@@ -402,6 +417,7 @@ async def _chat_with_personality(
     messages: List[ChatMessage],
     temperature: float,
     max_tokens: int,
+    bridge_suffix: Optional[str] = None,
 ) -> str:
     """Route a chat request through a built-in personality agent."""
     agent = personality_registry.get(personality_id)
@@ -417,6 +433,10 @@ async def _chat_with_personality(
     # Build system prompt
     is_first = len(messages) <= 1
     system_prompt = build_system_prompt(agent, memory, is_first_turn=is_first)
+
+    # DayPilot bridge: append propose-only instruction (never edits the base prompt).
+    if bridge_suffix:
+        system_prompt += "\n\n" + bridge_suffix
 
     # Build LLM messages
     llm_messages = [{"role": "system", "content": system_prompt}]
@@ -457,6 +477,9 @@ async def openai_chat_completions(
     req: ChatCompletionRequest,
     x_client_type: Optional[str] = Header(default=None, alias="X-Client-Type"),
     include_media: Optional[str] = Header(default=None, alias="X-Include-Media"),
+    x_tool_mode: Optional[str] = Header(default=None, alias="X-HomePilot-Tool-Mode"),
+    x_session_id: Optional[str] = Header(default=None, alias="X-HomePilot-Session-ID"),
+    x_bridge_version: Optional[str] = Header(default=None, alias="X-HomePilot-Bridge-Version"),
 ) -> Any:
     """OpenAI-compatible chat completions endpoint.
 
@@ -483,6 +506,18 @@ async def openai_chat_completions(
     temperature = req.temperature if req.temperature is not None else 0.7
     max_tokens = req.max_tokens if req.max_tokens is not None else 800
 
+    # DayPilot bridge (Batch A5). When DayPilot calls in propose-only mode, we
+    # append a separate system message telling the persona to propose actions as
+    # a machine block instead of performing them, then extract those directives
+    # into x_directives. Never mutates the persona's own prompt.
+    bridge = parse_bridge_headers(
+        x_client_type=x_client_type,
+        tool_mode=x_tool_mode,
+        session_id=x_session_id,
+        bridge_version=x_bridge_version,
+    )
+    bridge_suffix = propose_system_suffix() if (bridge.active and bridge.propose) else None
+
     # Track the resolved project_id for enriched mode
     resolved_project_id: Optional[str] = None
 
@@ -491,15 +526,18 @@ async def openai_chat_completions(
         resolved_project_id = project_data["id"]
         content = await _chat_with_persona_project(
             project_data["id"], req.messages, temperature, max_tokens,
-            client_type=x_client_type,
+            client_type=x_client_type, bridge_suffix=bridge_suffix,
         )
     elif model_type == "personality":
         content = await _chat_with_personality(
             model_id, req.messages, temperature, max_tokens,
+            bridge_suffix=bridge_suffix,
         )
     else:
         # Default: plain LLM passthrough
         llm_messages = [{"role": m.role, "content": m.content} for m in req.messages]
+        if bridge_suffix:
+            llm_messages.insert(0, {"role": "system", "content": bridge_suffix})
         try:
             result = await llm_chat(
                 llm_messages,
@@ -513,6 +551,13 @@ async def openai_chat_completions(
             raise HTTPException(502, f"LLM backend error: {e}")
 
     latency_ms = int((time.time() - t0) * 1000)
+
+    # --- DayPilot bridge: pull proposed directives out of the reply ---
+    # Done before [show:] resolution so the machine block never leaks into the
+    # visible content or an attachment. Only when a bridge client is calling.
+    bridge_directives: list[Dict[str, Any]] = []
+    if bridge.active:
+        content, bridge_directives = extract_directives(content)
 
     # --- Phase 3: Enriched response mode ---
     # Resolve [show:Label] tags into structured attachments when a
@@ -650,10 +695,77 @@ async def openai_chat_completions(
     # Append enriched fields only when active and present
     if enriched and x_attachments:
         response_data["x_attachments"] = x_attachments
-    if enriched and x_directives:
+
+    # DayPilot bridge fields — always present for a bridge client so DayPilot can
+    # correlate the turn, even when the persona proposed nothing this turn.
+    if bridge.active:
+        response_data["x_directives"] = {
+            "version": bridge.bridge_version,
+            "tool_mode": bridge.tool_mode,
+            "items": bridge_directives,
+        }
+        response_data["x_homepilot"] = build_x_homepilot(
+            bridge,
+            project_id=resolved_project_id,
+            model=req.model,
+            directive_count=len(bridge_directives),
+        )
+    elif enriched and x_directives:
         response_data["x_directives"] = x_directives
 
     return response_data
+
+
+@router.get("/v1/integrations/daypilot/capabilities", dependencies=[Depends(require_ollabridge_api_key)])
+async def daypilot_capabilities() -> Dict[str, Any]:
+    """Advertise this HomePilot's DayPilot-bridge support (Batch A5).
+
+    Lets DayPilot feature-detect a bridge-aware HomePilot (propose-only tool
+    mode, the directive/capability vocabulary, and limits) without a chat
+    round-trip. Static and side-effect free.
+    """
+    if not _compat_enabled:
+        raise HTTPException(503, "Persona API is disabled. Enable it in Settings > OllaBridge Gateway.")
+    return capabilities_document()
+
+
+@router.get("/v1/integrations/daypilot/identity", dependencies=[Depends(require_ollabridge_api_key)])
+async def daypilot_identity(
+    authorization: Optional[str] = Header(default=None),
+    homepilot_session: Optional[str] = Cookie(default=None),
+) -> Any:
+    """Report the HomePilot account this DayPilot connection is bound to.
+
+    Multi-account security: DayPilot records the returned ``account_ref`` on the
+    connection and stamps every synced agent with it, so one user's agents can
+    never blend with another's. A per-user token resolves to that user (scope
+    ``account``); the shared instance key resolves to ``shared``. No secret is
+    returned. Additive and side-effect free.
+    """
+    if not _compat_enabled:
+        raise HTTPException(503, "Persona API is disabled. Enable it in Settings > OllaBridge Gateway.")
+
+    account_ref, account_label, authenticated, scope = "shared", "Shared instance key", False, "shared"
+    try:
+        from .users import ensure_users_tables, _validate_token
+        ensure_users_tables()
+        token = ""
+        if authorization and authorization.lower().startswith("bearer "):
+            token = authorization.split(" ", 1)[1].strip()
+        if not token and homepilot_session:
+            token = homepilot_session.strip()
+        user = _validate_token(token) if token else None
+        if user:
+            account_ref = f"user:{user['id']}"
+            account_label = user.get("display_name") or user.get("email") or user.get("username") or account_ref
+            authenticated, scope = True, "account"
+    except Exception:  # noqa: BLE001 - identity resolution is best-effort; default to shared
+        pass
+
+    return identity_document(
+        account_ref=account_ref, account_label=account_label,
+        authenticated=authenticated, scope=scope,
+    )
 
 
 @router.get("/v1/models", dependencies=[Depends(require_ollabridge_api_key)])

--- a/backend/tests/test_daypilot_bridge.py
+++ b/backend/tests/test_daypilot_bridge.py
@@ -1,0 +1,165 @@
+"""Tests for the DayPilot bridge (Batch A5).
+
+Covers the pure protocol module (header parsing, propose-mode instruction,
+directive extraction, capabilities document) and its wiring into the
+OpenAI-compatible chat endpoint.
+"""
+import pytest
+
+from app.daypilot_bridge import bridge as B
+
+
+# ---------------------------------------------------------------------------
+# Header parsing
+# ---------------------------------------------------------------------------
+
+class TestParseHeaders:
+    def test_daypilot_client_activates_bridge(self):
+        ctx = B.parse_bridge_headers(x_client_type="daypilot", tool_mode=None, session_id=None, bridge_version=None)
+        assert ctx.active is True
+        assert ctx.tool_mode == "propose" and ctx.propose is True
+
+    def test_explicit_tool_mode_header_activates(self):
+        ctx = B.parse_bridge_headers(x_client_type=None, tool_mode="propose", session_id="s1", bridge_version="1")
+        assert ctx.active is True and ctx.session_id == "s1" and ctx.bridge_version == 1
+
+    def test_ordinary_client_is_not_active(self):
+        ctx = B.parse_bridge_headers(x_client_type="vr-chatbot", tool_mode=None, session_id=None, bridge_version=None)
+        assert ctx.active is False
+
+    def test_unknown_tool_mode_falls_back_to_propose(self):
+        ctx = B.parse_bridge_headers(x_client_type="daypilot", tool_mode="execute-please", session_id=None, bridge_version=None)
+        assert ctx.tool_mode == "propose"  # safe default; HomePilot never executes for DayPilot
+
+    def test_blank_session_id_becomes_none(self):
+        ctx = B.parse_bridge_headers(x_client_type="daypilot", tool_mode="propose", session_id="   ", bridge_version="x")
+        assert ctx.session_id is None
+        assert ctx.bridge_version == B.BRIDGE_VERSION  # non-int version falls back
+
+
+# ---------------------------------------------------------------------------
+# Directive extraction
+# ---------------------------------------------------------------------------
+
+class TestExtractDirectives:
+    def _block(self, payload: str) -> str:
+        return f"Sure, on it. [[DAYPILOT_DIRECTIVES]]{payload}[[/DAYPILOT_DIRECTIVES]]"
+
+    def test_no_block_returns_content_unchanged(self):
+        visible, directives = B.extract_directives("Just a normal reply.")
+        assert visible == "Just a normal reply." and directives == []
+
+    def test_task_create_directive(self):
+        visible, directives = B.extract_directives(
+            self._block('{"directives":[{"type":"task.create","title":"Draft Q3 report","priority":"high"}]}')
+        )
+        assert visible == "Sure, on it."  # machine block stripped
+        assert directives == [{"type": "task.create", "title": "Draft Q3 report", "priority": "high"}]
+
+    def test_action_propose_requires_valid_capability(self):
+        _, ok = B.extract_directives(
+            self._block('{"directives":[{"type":"daypilot.action.propose","capability":"email.send","summary":"Email Bob"}]}')
+        )
+        assert ok and ok[0]["capability"] == "email.send"
+        _, bad = B.extract_directives(
+            self._block('{"directives":[{"type":"daypilot.action.propose","capability":"launch.missiles","summary":"nope"}]}')
+        )
+        assert bad == []  # invalid capability dropped, reply preserved
+
+    def test_unknown_directive_type_dropped(self):
+        _, directives = B.extract_directives(
+            self._block('{"directives":[{"type":"delete.everything"},{"type":"task.complete","ref":"t1"}]}')
+        )
+        assert [d["type"] for d in directives] == ["task.complete"]
+
+    def test_malformed_json_preserves_reply(self):
+        visible, directives = B.extract_directives(self._block("{not json"))
+        assert visible == "Sure, on it." and directives == []
+
+    def test_bare_list_payload_supported(self):
+        _, directives = B.extract_directives(self._block('[{"type":"progress.report","percent":250}]'))
+        assert directives[0]["percent"] == 100  # clamped to [0,100]
+
+    def test_directive_cap_enforced(self):
+        many = ",".join(['{"type":"task.create","title":"t"}'] * 30)
+        _, directives = B.extract_directives(self._block(f'{{"directives":[{many}]}}'))
+        assert len(directives) == B.MAX_DIRECTIVES_PER_TURN
+
+    def test_code_fenced_block_tolerated(self):
+        content = 'Done.\n```\n[[DAYPILOT_DIRECTIVES]]{"directives":[{"type":"task.create","title":"x"}]}[[/DAYPILOT_DIRECTIVES]]\n```'
+        visible, directives = B.extract_directives(content)
+        assert "DAYPILOT_DIRECTIVES" not in visible
+        assert directives and directives[0]["type"] == "task.create"
+
+
+# ---------------------------------------------------------------------------
+# Propose suffix + capabilities document
+# ---------------------------------------------------------------------------
+
+class TestBridgeMetadata:
+    def test_propose_suffix_mentions_contract(self):
+        s = B.propose_system_suffix()
+        assert "propose" in s.lower() and "DAYPILOT_DIRECTIVES" in s
+        assert "CANNOT" in s  # the persona must not act on the outside world itself
+        # §13 guardrails: no raw tool calls / model names, no premature "complete".
+        assert "raw tool calls" in s and "complete before" in s
+
+    def test_capabilities_document_shape(self):
+        doc = B.capabilities_document()
+        assert doc["bridge_version"] == B.BRIDGE_VERSION
+        assert "propose" in doc["tool_modes"]
+        assert "task.create" in doc["directives"]
+        assert "email.send" in doc["capabilities"]
+        assert doc["headers"]["tool_mode"] == "X-HomePilot-Tool-Mode"
+
+
+# ---------------------------------------------------------------------------
+# Endpoint wiring
+# ---------------------------------------------------------------------------
+
+class TestBridgeEndpoint:
+    def _headers(self):
+        return {
+            "X-Client-Type": "daypilot",
+            "X-HomePilot-Tool-Mode": "propose",
+            "X-HomePilot-Session-ID": "sess-abc",
+            "X-HomePilot-Bridge-Version": "1",
+        }
+
+    def test_capabilities_endpoint(self, client, mock_outbound):
+        resp = client.get("/v1/integrations/daypilot/capabilities")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["default_tool_mode"] == "propose"
+        assert "x_directives" in data["response_fields"]
+        assert data["endpoints"]["identity"] == "/v1/integrations/daypilot/identity"
+
+    def test_identity_endpoint_reports_account_binding(self, client, mock_outbound):
+        # Shared-key path (no user token) → shared scope, no secret leaked.
+        resp = client.get("/v1/integrations/daypilot/identity")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["scope"] == "shared" and data["account_ref"] == "shared"
+        assert data["authenticated"] is False
+        assert "key" not in resp.text.lower() or "shared instance key" in resp.text.lower()
+
+    def test_bridge_client_gets_correlation_fields(self, client, mock_outbound):
+        resp = client.post(
+            "/v1/chat/completions",
+            headers=self._headers(),
+            json={"model": "personality:assistant", "messages": [{"role": "user", "content": "Hi"}]},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        # Even with no proposal this turn, the bridge fields are present.
+        assert data["x_homepilot"]["session_id"] == "sess-abc"
+        assert data["x_homepilot"]["tool_mode"] == "propose"
+        assert data["x_directives"]["items"] == []
+
+    def test_non_bridge_client_has_no_bridge_fields(self, client, mock_outbound):
+        resp = client.post(
+            "/v1/chat/completions",
+            json={"model": "personality:assistant", "messages": [{"role": "user", "content": "Hi"}]},
+        )
+        assert resp.status_code == 200
+        assert "x_homepilot" not in resp.json()

--- a/docs/daypilot-bridge.md
+++ b/docs/daypilot-bridge.md
@@ -1,0 +1,115 @@
+# DayPilot bridge (propose-only)
+
+HomePilot owns the agents; **DayPilot connects to them and manages their work.**
+DayPilot talks to a HomePilot persona over the OpenAI-compatible
+`POST /v1/chat/completions` endpoint in **propose-only** mode. The persona
+reasons with its full identity and memory but never performs external writes —
+it *proposes* structured operations, and DayPilot validates and approves them.
+
+Implemented in `backend/app/daypilot_bridge/` and wired into
+`backend/app/openai_compat_endpoint.py`.
+
+## Request headers
+
+| Header | Value | Meaning |
+| --- | --- | --- |
+| `X-Client-Type` | `daypilot` | Identifies the bridge client (activates bridge fields). |
+| `X-HomePilot-Tool-Mode` | `propose` | Only mode used in production. Unknown values fall back to `propose`. |
+| `X-HomePilot-Session-ID` | opaque id | DayPilot's external session id, echoed back for correlation. |
+| `X-HomePilot-Bridge-Version` | `1` | Protocol version. |
+
+The bridge is *active* when `X-Client-Type: daypilot` **or** any bridge header is
+present. In propose mode HomePilot appends a **separate** system message telling
+the persona it cannot act on the outside world itself and how to propose actions.
+The persona's own system prompt is never modified.
+
+## How a persona proposes an action
+
+The persona replies normally, then — only when it intends a concrete action or
+wants to track work — appends one machine block at the very end:
+
+```
+[[DAYPILOT_DIRECTIVES]]{"directives":[
+  {"type":"task.create","title":"Draft the Q3 report","priority":"high"},
+  {"type":"daypilot.action.propose","capability":"email.send","summary":"Email Bob the update","arguments":{"to":"bob@acme.com"}}
+]}[[/DAYPILOT_DIRECTIVES]]
+```
+
+HomePilot parses that block, **strips it from the visible reply**, validates it
+defensively (model output is untrusted), and returns the result. Malformed JSON
+or unknown directive types are dropped while the plain-text reply is preserved.
+
+**Allowed directive types:** `task.create`, `task.update`, `task.complete`,
+`task.block`, `progress.report`, `delegate.request`, `daypilot.action.propose`,
+`artifact.attach`.
+
+**Capabilities** (only for `daypilot.action.propose`; each still becomes a draft
++ Approval on DayPilot): `email.send`, `calendar.create`, `calendar.update`,
+`calendar.cancel`, `coding.run`, `github.change`, `message.send`,
+`document.generate`, `finance.change`, `hr.change`, `system.change`.
+
+Bounds: at most 12 directives/turn; titles ≤ 200 chars; text ≤ 4000 chars.
+
+## Response fields
+
+For a bridge client the response carries two extra fields alongside the standard
+OpenAI-compatible body:
+
+```jsonc
+{
+  "choices": [ ... ],                 // visible reply, machine block removed
+  "x_directives": {
+    "version": 1,
+    "tool_mode": "propose",
+    "items": [ /* validated directives */ ]
+  },
+  "x_homepilot": {
+    "bridge_version": 1,
+    "tool_mode": "propose",
+    "session_id": "<echoed>",
+    "project_id": "<persona project id or null>",
+    "model": "persona:<id>",
+    "directive_count": 2
+  }
+}
+```
+
+Both fields are present on every bridge turn — even when the persona proposed
+nothing (`items: []`) — so DayPilot can always correlate the turn.
+
+## Capability discovery
+
+`GET /v1/integrations/daypilot/capabilities` returns a static document listing
+the supported tool modes, directive types, capabilities, limits, and header
+names — so DayPilot can feature-detect a bridge-aware HomePilot without a chat
+round-trip.
+
+## Account identity (multi-account security)
+
+`GET /v1/integrations/daypilot/identity` reports which HomePilot account a
+DayPilot connection is bound to, so a user's agents can never blend with
+another's:
+
+```jsonc
+{ "bridge_version": 1, "account_ref": "user:42", "account_label": "Ana", "authenticated": true, "scope": "account" }
+```
+
+- A request carrying a **specific user's token** (Bearer JWT or the
+  `homepilot_session` cookie) resolves to that user — `scope: "account"`, and
+  DayPilot syncs only that account's agents.
+- The **shared instance key** resolves to `scope: "shared"` (`account_ref:
+  "shared"`) — published personas with no single owner.
+
+No secret is ever returned. DayPilot records `account_ref` on the connection and
+stamps every synced agent with it; if the bound account changes, DayPilot
+re-scopes rather than mixing accounts. Cloud (`homepilot.ruslanmv.com`) and local
+installs use the same endpoint, so a cloud connection is bound to the cloud
+account automatically.
+
+## Guarantees
+
+- HomePilot never sends email, changes files, schedules events, or completes
+  tasks on DayPilot's behalf — it only proposes.
+- The persona's stored system prompt and memory are untouched by the bridge.
+- Non-bridge clients (VR, plain OpenAI SDKs) see no bridge fields and no
+  behavior change.


### PR DESCRIPTION
Extend the propose-only system suffix with the AI-behavior guardrails: the
persona must speak in plain language — no raw tool calls, JSON, function names,
or the underlying model name — and must never claim a task is complete before
it actually is (DayPilot marks work complete only after approval + execution).

Additive; the persona's own prompt is untouched. Bridge suite green.