### PR TITLE
Deploy: thread OllaBridge account feature flags into Oracle + image b…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -321,7 +321,7 @@ NOTION_WRITE_ENABLED=false
 # flip it to a premium feature with the two flags below.
 #
 # HOMEPILOT_COMPUTE_MODE=local             # local | ollabridge_cloud | auto
-# OLLABRIDGE_CLOUD_URL=https://ruslanmv-ollabridge.hf.space   # the live Space
+# OLLABRIDGE_CLOUD_URL=https://app.ollabridge.com   # canonical Cloud base URL
 # OLLABRIDGE_CLOUD_TOKEN=                   # cloud access token (Bearer/ob_ key)
 # OLLABRIDGE_CLOUD_IMAGE_MODEL=flux-schnell
 # OLLABRIDGE_CLOUD_VIDEO_MODEL=ltx-video

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -71,5 +71,12 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Frontend feature flags baked at build time. Empty = today's behavior
+          # (OFF); set these as repository variables to enable the OllaBridge
+          # account UX / BFF session for every deployment that uses this image.
+          build-args: |
+            VITE_ACCOUNTS_UX=${{ vars.VITE_ACCOUNTS_UX }}
+            VITE_BFF_SESSION=${{ vars.VITE_BFF_SESSION }}
+            VITE_OLLABRIDGE_CLOUD_URL=${{ vars.VITE_OLLABRIDGE_CLOUD_URL }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/oracle.yml
+++ b/.github/workflows/oracle.yml
@@ -132,12 +132,22 @@ jobs:
           API_KEY: ${{ secrets.HOMEPILOT_API_KEY || secrets.API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          # OllaBridge account features for the hosted web edition. Non-secret
+          # flags/URL default sensibly below; set them on the oracle-production
+          # environment (as variables) to override. OLLABRIDGE_CLOUD_TOKEN is an
+          # optional operator-wide fallback (secret) — per-user linking does not
+          # need it.
+          OLLABRIDGE_CLOUD_URL: ${{ vars.OLLABRIDGE_CLOUD_URL || secrets.OLLABRIDGE_CLOUD_URL }}
+          OLLABRIDGE_CLOUD_TOKEN: ${{ secrets.OLLABRIDGE_CLOUD_TOKEN }}
+          HOMEPILOT_MIRROR_BFF_ENABLED: ${{ vars.HOMEPILOT_MIRROR_BFF_ENABLED }}
+          HOMEPILOT_BFF_SESSION_ENABLED: ${{ vars.HOMEPILOT_BFF_SESSION_ENABLED }}
+          HOMEPILOT_ACCOUNT_PROVIDERS_ENABLED: ${{ vars.HOMEPILOT_ACCOUNT_PROVIDERS_ENABLED }}
         with:
           host: ${{ vars.ORACLE_HOST || secrets.ORACLE_HOST }}
           username: ${{ vars.ORACLE_USER || secrets.ORACLE_USER }}
           key: ${{ secrets.ORACLE_SSH_PRIVATE_KEY }}
           port: ${{ vars.ORACLE_SSH_PORT || secrets.ORACLE_SSH_PORT || 22 }}
-          envs: IMAGE_REF,HOMEPILOT_DOMAIN,ACME_EMAIL,API_KEY,OPENAI_API_KEY,ANTHROPIC_API_KEY
+          envs: IMAGE_REF,HOMEPILOT_DOMAIN,ACME_EMAIL,API_KEY,OPENAI_API_KEY,ANTHROPIC_API_KEY,OLLABRIDGE_CLOUD_URL,OLLABRIDGE_CLOUD_TOKEN,HOMEPILOT_MIRROR_BFF_ENABLED,HOMEPILOT_BFF_SESSION_ENABLED,HOMEPILOT_ACCOUNT_PROVIDERS_ENABLED
           script_stop: true
           script: |
             set -Eeuo pipefail
@@ -188,6 +198,16 @@ jobs:
               echo "INTERACTIVE_ENABLED=true"
               echo "INTERACTIVE_PLAYBACK_LLM=false"
               echo "INTERACTIVE_PLAYBACK_RENDER=false"
+              # OllaBridge account features (hosted web edition). Flags default
+              # ON here so remote providers work out of the box; set the matching
+              # variable to "false" on oracle-production to disable. The cloud URL
+              # defaults to the canonical host. OLLABRIDGE_CLOUD_TOKEN is written
+              # only when provided (optional operator-wide fallback).
+              echo "OLLABRIDGE_CLOUD_URL=${OLLABRIDGE_CLOUD_URL:-https://app.ollabridge.com}"
+              [ -n "${OLLABRIDGE_CLOUD_TOKEN:-}" ] && echo "OLLABRIDGE_CLOUD_TOKEN=${OLLABRIDGE_CLOUD_TOKEN}"
+              echo "HOMEPILOT_MIRROR_BFF_ENABLED=${HOMEPILOT_MIRROR_BFF_ENABLED:-true}"
+              echo "HOMEPILOT_BFF_SESSION_ENABLED=${HOMEPILOT_BFF_SESSION_ENABLED:-true}"
+              echo "HOMEPILOT_ACCOUNT_PROVIDERS_ENABLED=${HOMEPILOT_ACCOUNT_PROVIDERS_ENABLED:-true}"
             } | sudo tee .env >/dev/null
 
             # Run via sudo so it works before the docker-group membership added

--- a/apps/mobile/src/lib/client.ts
+++ b/apps/mobile/src/lib/client.ts
@@ -9,7 +9,7 @@ export const DEFAULT_BASE_URL = 'http://localhost:8000';
 
 // The compute backend (image jobs, devices, sharing) is OllaBridge Cloud. The
 // Connect screen defaults to this so a fresh install only needs an access token.
-export const DEFAULT_CLOUD_URL = 'https://ruslanmv-ollabridge.hf.space';
+export const DEFAULT_CLOUD_URL = 'https://app.ollabridge.com';
 
 let baseUrl = DEFAULT_BASE_URL;
 

--- a/backend/app/account_providers.py
+++ b/backend/app/account_providers.py
@@ -1,0 +1,288 @@
+"""
+Account Providers BFF endpoint (ADDITIVE, FEATURE-FLAGGED) — Step 2.
+
+Gives HomePilot **Web** a single, same-origin, authenticated aggregate that
+surfaces the remote providers shared by the signed-in user's OllaBridge account,
+so Settings → Providers can list them (e.g. "Ollama — Gaming PC (OllaBridge), 1
+model") without the browser ever holding a cloud token or relay URL.
+
+Route
+-----
+    GET /v1/account/providers
+
+Design / security posture
+-------------------------
+* **Feature-flagged.** ``HOMEPILOT_ACCOUNT_PROVIDERS_ENABLED`` (default off).
+  When off, ``main.py`` does not mount the router — zero behavior change. It is
+  mounted independently of the mirror RPC/jobs plane so a linked user can see
+  their shared providers without the whole mirror BFF being enabled.
+* **Reuses the mirror BFF security seam.** Auth (``_require_user``) and the
+  server-side cloud-credential resolution (``_resolve_cloud_credentials``) come
+  straight from ``mirror_proxy``: the caller is an authenticated HomePilot user,
+  the OllaBridge token is resolved server-side (per-user registry → persistent
+  store → operator env), and it is **never** returned to the browser.
+* **Compatibility fallback (documented, not the long-term contract).** The cloud
+  currently exposes an OpenAI-compatible model list plus a device list, not a
+  first-class provider inventory. Until it does, we treat the caller's own
+  ``shared_device`` models as the Ollama remote provider, grouped by owning
+  device (parsed from ``owned_by = "relay:<device_id>"`` or an explicit
+  ``device_id``), and enrich names/online-state from ``GET /v1/devices`` when it
+  is available. The preferred contract is a node/provider inventory the cloud
+  returns directly.
+
+Response semantics
+------------------
+    Not signed in                          → 401 {ok:false, error:not_authenticated}
+    Signed in but not linked               → 200 {ok:true,  linked:false, providers:[]}
+    Cloud unavailable / invalid response   → 502 {ok:false, error:cloud_unavailable}
+    Cloud OK with no shared backends       → 200 {ok:true,  linked:true,  providers:[]}
+"""
+from __future__ import annotations
+
+import logging
+import os
+import re
+import uuid
+from typing import Any, Dict, List, Optional
+
+import httpx
+from fastapi import APIRouter, Cookie, Header, HTTPException
+from fastapi.responses import JSONResponse
+
+from .mirror_proxy import (
+    _cloud_base,
+    _require_user,
+    _resolve_cloud_credentials,
+)
+
+logger = logging.getLogger("homepilot.account_providers")
+
+router = APIRouter(prefix="/v1/account", tags=["account-providers"])
+
+# Upstream timeouts (connect, read). Two small GETs, kept snappy so Settings
+# never hangs on a slow cloud.
+_CONNECT_TIMEOUT = 5.0
+_READ_TIMEOUT = 15.0
+
+# The caller's own shared-device models are ``owned_by = "relay:<device_id>"``
+# in the OpenAI-compatible list. Constrain the id charset so a malformed value
+# can never smuggle anything into the provider id we hand back.
+_RELAY_OWNER_RE = re.compile(r"^relay:(?P<dev>[A-Za-z0-9._:-]{1,128})$")
+
+
+def is_enabled() -> bool:
+    return os.getenv("HOMEPILOT_ACCOUNT_PROVIDERS_ENABLED", "false").strip().lower() in {
+        "1", "true", "yes", "on",
+    }
+
+
+def _json(status: int, body: Dict[str, Any], rid: str) -> JSONResponse:
+    body.setdefault("request_id", rid)
+    return JSONResponse(status_code=status, content=body, headers={"Cache-Control": "no-store"})
+
+
+def _device_id_of(model: Dict[str, Any]) -> str:
+    """Owning device id for a shared-device model.
+
+    Prefers explicit fields (a future cloud contract), then falls back to
+    parsing ``owned_by = "relay:<device_id>"`` — today's shape.
+    """
+    for key in ("device_id", "deviceId"):
+        val = model.get(key)
+        if val:
+            return str(val)
+    match = _RELAY_OWNER_RE.match(str(model.get("owned_by") or ""))
+    return match.group("dev") if match else ""
+
+
+def _parse_device_meta(payload: Any) -> Dict[str, Dict[str, Any]]:
+    """Map ``device_id -> {name, online}`` from the cloud ``/v1/devices`` list.
+
+    Absent / 404 / non-list is tolerated: names simply fall back to the id and
+    online defaults are decided by the caller.
+    """
+    meta: Dict[str, Dict[str, Any]] = {}
+    if not isinstance(payload, list):
+        return meta
+    for d in payload:
+        if not isinstance(d, dict):
+            continue
+        did = d.get("id")
+        if not did:
+            continue
+        meta[str(did)] = {
+            "name": d.get("name") or str(did),
+            "online": bool(d.get("online", False)),
+            "has_online": "online" in d,
+        }
+    return meta
+
+
+def _build_providers(models_payload: Any, device_meta: Dict[str, Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Group the caller's shared-device models into one Ollama provider per device."""
+    data = models_payload.get("data") if isinstance(models_payload, dict) else models_payload
+    if not isinstance(data, list):
+        return []
+
+    grouped: Dict[str, List[str]] = {}
+    for m in data:
+        if not isinstance(m, dict):
+            continue
+        # Own-node models are tagged shared_device (``x_source`` today, legacy
+        # ``source``). Anything else — route aliases, cloud catalog, personas —
+        # is not a shared remote backend and is skipped.
+        source = m.get("x_source") or m.get("source")
+        if source != "shared_device":
+            continue
+        dev_id = _device_id_of(m)
+        mid = m.get("id")
+        if not dev_id or not mid:
+            continue
+        bucket = grouped.setdefault(dev_id, [])
+        if mid not in bucket:
+            bucket.append(mid)
+
+    providers: List[Dict[str, Any]] = []
+    for dev_id, model_ids in sorted(grouped.items()):
+        meta = device_meta.get(dev_id, {})
+        name = meta.get("name") or dev_id
+        # A device advertising relay models is connected (offline devices don't
+        # surface relay models). Honor an explicit offline flag from
+        # /v1/devices when present; otherwise treat as online.
+        online = bool(meta["online"]) if meta.get("has_online") else True
+        providers.append({
+            "id": f"ollabridge:{dev_id}:ollama",
+            "label": f"Ollama — {name} (OllaBridge)",
+            "origin": "ollabridge",
+            "capability": "chat",
+            "online": online,
+            "modelCount": len(model_ids),
+            "nodeId": dev_id,
+            "backend": "ollama",
+        })
+    return providers
+
+
+async def _cloud_get(client: httpx.AsyncClient, base: str, path: str, token: str, rid: str) -> httpx.Response:
+    return await client.get(
+        f"{base}{path}",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json",
+            "X-Request-Id": rid,
+        },
+    )
+
+
+@router.get("/providers")
+async def account_providers(
+    authorization: Optional[str] = Header(default=None),
+    homepilot_session: Optional[str] = Cookie(default=None),
+) -> JSONResponse:
+    """Aggregate the signed-in user's shared OllaBridge providers (server-side)."""
+    rid = "apr_" + uuid.uuid4().hex[:16]
+
+    # 1. Authenticate — stable ``not_authenticated`` code on 401.
+    try:
+        user = _require_user(authorization, homepilot_session)
+    except HTTPException as exc:
+        if exc.status_code == 401:
+            return _json(401, {
+                "ok": False,
+                "error": "not_authenticated",
+                "message": "Sign in to view your account providers.",
+                "providers": [],
+            }, rid)
+        raise
+    user_id = str(user.get("id", ""))
+
+    # 2. Resolve the server-side cloud credentials. The seam raises 503 when no
+    #    token is available — that means "signed in but not linked", which the
+    #    contract reports as a successful, empty, unlinked result (not an error
+    #    the Settings panel would surface as a failure).
+    try:
+        base, token = _resolve_cloud_credentials(user)
+    except HTTPException as exc:
+        if exc.status_code == 503:
+            return _json(200, {
+                "ok": True,
+                "linked": False,
+                "providers": [],
+                "cloud": _cloud_base(),
+            }, rid)
+        raise
+
+    # 3. Query the canonical cloud inventory (models + devices), server-side.
+    timeout = httpx.Timeout(_READ_TIMEOUT, connect=_CONNECT_TIMEOUT)
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            models_resp = await _cloud_get(client, base, "/ollama/v1/models", token, rid)
+            # Devices give friendly names + online state; /v1/devices is 404
+            # when device sharing is disabled on the cloud, and may fail
+            # independently — tolerated as "no metadata", never fatal.
+            try:
+                dev_resp: Optional[httpx.Response] = await _cloud_get(
+                    client, base, "/v1/devices", token, rid)
+            except httpx.RequestError:
+                dev_resp = None
+    except httpx.TimeoutException:
+        logger.warning("[account-providers %s] cloud timeout user=%s", rid, user_id)
+        return _json(502, {
+            "ok": False,
+            "error": "cloud_unavailable",
+            "message": "The OllaBridge cloud did not respond in time.",
+            "providers": [],
+        }, rid)
+    except httpx.RequestError as exc:
+        logger.warning("[account-providers %s] cloud error user=%s: %s", rid, user_id, type(exc).__name__)
+        return _json(502, {
+            "ok": False,
+            "error": "cloud_unavailable",
+            "message": "Could not reach the OllaBridge cloud.",
+            "providers": [],
+        }, rid)
+
+    # A 401 from upstream means the server-side token expired/was revoked.
+    # Present it as "not linked" so the UI prompts a re-link instead of showing
+    # a hard error the user can't act on.
+    if models_resp.status_code == 401:
+        return _json(200, {
+            "ok": True,
+            "linked": False,
+            "providers": [],
+            "cloud": _cloud_base(),
+        }, rid)
+    if models_resp.status_code >= 400:
+        return _json(502, {
+            "ok": False,
+            "error": "cloud_unavailable",
+            "message": f"The OllaBridge cloud returned HTTP {models_resp.status_code}.",
+            "providers": [],
+        }, rid)
+
+    try:
+        models_payload = models_resp.json()
+    except ValueError:
+        # HTML or other non-JSON where the model list was expected.
+        return _json(502, {
+            "ok": False,
+            "error": "cloud_unavailable",
+            "message": "The OllaBridge cloud returned a non-JSON model list.",
+            "providers": [],
+        }, rid)
+
+    device_meta: Dict[str, Dict[str, Any]] = {}
+    if dev_resp is not None and dev_resp.status_code < 400:
+        try:
+            device_meta = _parse_device_meta(dev_resp.json())
+        except ValueError:
+            device_meta = {}
+
+    providers = _build_providers(models_payload, device_meta)
+    logger.info("[account-providers %s] user=%s providers=%d", rid, user_id, len(providers))
+    return _json(200, {
+        "ok": True,
+        "linked": True,
+        "providers": providers,
+        "cloud": _cloud_base(),
+    }, rid)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -95,7 +95,7 @@ VIDEO_MODEL = os.getenv("VIDEO_MODEL", "svd").strip()  # svd, wan-2.2, seedream
 #   auto             — local GPU when healthy, else a linked OllaBridge device
 HOMEPILOT_COMPUTE_MODE = os.getenv("HOMEPILOT_COMPUTE_MODE", "local").strip().lower()
 OLLABRIDGE_CLOUD_URL = os.getenv(
-    "OLLABRIDGE_CLOUD_URL", "https://ruslanmv-ollabridge.hf.space"
+    "OLLABRIDGE_CLOUD_URL", "https://app.ollabridge.com"
 ).rstrip("/")
 OLLABRIDGE_CLOUD_TOKEN = os.getenv("OLLABRIDGE_CLOUD_TOKEN", "").strip()
 OLLABRIDGE_CLOUD_IMAGE_MODEL = os.getenv("OLLABRIDGE_CLOUD_IMAGE_MODEL", "flux-schnell").strip()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -243,6 +243,20 @@ try:
 except Exception as _e:  # pragma: no cover - defensive
     print(f"[mirror-bff] disabled: {_e}")
 
+# Account Providers BFF (/v1/account/providers) — ADDITIVE, FEATURE-FLAGGED
+# (HOMEPILOT_ACCOUNT_PROVIDERS_ENABLED). Same-origin aggregate that surfaces the
+# remote providers shared by the signed-in user's OllaBridge account for
+# Settings → Providers. Reuses the mirror BFF security seam; the cloud token
+# stays server-side. Mounted independently of the mirror RPC/jobs plane so a
+# linked user sees shared providers without enabling the whole mirror BFF.
+try:
+    from . import account_providers as _account_providers
+    if _account_providers.is_enabled():
+        app.include_router(_account_providers.router)
+        print("[account-providers] mounted /v1/account/providers")
+except Exception as _e:  # pragma: no cover - defensive
+    print(f"[account-providers] disabled: {_e}")
+
 # --- Voice call (/v1/voice-call/*) — ADDITIVE, FEATURE-FLAGGED ---------------
 # Fully off by default. Enable with ``VOICE_CALL_ENABLED=true``. If anything
 # in the voice_call module raises on import (bad migration, missing dep, …)

--- a/backend/tests/test_account_providers.py
+++ b/backend/tests/test_account_providers.py
@@ -1,0 +1,328 @@
+"""Tests for the Account Providers BFF endpoint (Step 2).
+
+Drives GET /v1/account/providers with a mocked OllaBridge Cloud upstream so we
+can assert: contract status semantics (not_authenticated, not-linked, cloud
+unavailable, linked-empty), shared-device grouping into ProviderOption rows,
+per-user tenant isolation, device-name/online enrichment, the
+owned_by="relay:<id>" compatibility fallback, graceful /v1/devices 404, and
+that the server-side cloud token never leaks to the client.
+"""
+import os
+import sys
+
+import httpx
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+_BACKEND_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _BACKEND_ROOT not in sys.path:
+    sys.path.insert(0, _BACKEND_ROOT)
+
+from app import account_providers as ap  # noqa: E402
+from app import mirror_proxy as mp  # noqa: E402
+
+
+# ── Fake upstream ────────────────────────────────────────────────────────────
+
+class _FakeResp:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        if isinstance(self._payload, ValueError):
+            raise self._payload
+        return self._payload
+
+
+class _FakeClient:
+    """Scripts responses per upstream path and records the calls made."""
+    # path -> {"status": int, "payload": obj}
+    routes = {}
+    calls = []            # list of (method, url, headers)
+    raise_on = None       # {path_substr: Exception} to simulate transport errors
+
+    def __init__(self, *a, **k):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def get(self, url, headers=None):
+        _FakeClient.calls.append(("GET", url, headers or {}))
+        if _FakeClient.raise_on:
+            for frag, exc in _FakeClient.raise_on.items():
+                if frag in url:
+                    raise exc
+        for path, script in _FakeClient.routes.items():
+            if url.endswith(path):
+                return _FakeResp(script["status"], script["payload"])
+        return _FakeResp(404, {"detail": "not found"})
+
+
+@pytest.fixture(autouse=True)
+def _wire(monkeypatch):
+    # Fixed signed-in user by default (tests override for the 401/isolation cases).
+    monkeypatch.setattr(ap, "_require_user", lambda a, c: {"id": "user-1"})
+    monkeypatch.setattr(mp._cfg, "OLLABRIDGE_CLOUD_URL", "https://cloud.example", raising=False)
+    monkeypatch.setattr(mp._cfg, "OLLABRIDGE_CLOUD_TOKEN", "operator-token", raising=False)
+    monkeypatch.setattr(ap.httpx, "AsyncClient", _FakeClient)
+    _FakeClient.routes = {}
+    _FakeClient.calls = []
+    _FakeClient.raise_on = None
+    with mp._registry_lock:
+        mp._USER_CLOUD_TOKENS.clear()
+    yield
+
+
+def _client():
+    app = FastAPI()
+    app.include_router(ap.router)
+    return TestClient(app)
+
+
+# ── Flag parsing ─────────────────────────────────────────────────────────────
+
+def test_is_enabled_env(monkeypatch):
+    monkeypatch.delenv("HOMEPILOT_ACCOUNT_PROVIDERS_ENABLED", raising=False)
+    assert ap.is_enabled() is False
+    for v in ("1", "true", "YES", "on"):
+        monkeypatch.setenv("HOMEPILOT_ACCOUNT_PROVIDERS_ENABLED", v)
+        assert ap.is_enabled() is True
+    monkeypatch.setenv("HOMEPILOT_ACCOUNT_PROVIDERS_ENABLED", "off")
+    assert ap.is_enabled() is False
+
+
+# ── Contract: status semantics ───────────────────────────────────────────────
+
+def test_not_authenticated_returns_stable_401(monkeypatch):
+    def _raise(a, c):
+        raise HTTPException(status_code=401, detail="Authentication required")
+    monkeypatch.setattr(ap, "_require_user", _raise)
+    r = _client().get("/v1/account/providers")
+    assert r.status_code == 401
+    body = r.json()
+    assert body["ok"] is False
+    assert body["error"] == "not_authenticated"
+    assert body["providers"] == []
+
+
+def test_signed_in_but_not_linked_returns_200_unlinked(monkeypatch):
+    # No per-user token and no operator token → seam raises 503 → contract 200.
+    monkeypatch.setattr(mp._cfg, "OLLABRIDGE_CLOUD_TOKEN", "", raising=False)
+    r = _client().get("/v1/account/providers")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is True
+    assert body["linked"] is False
+    assert body["providers"] == []
+    # Nothing was queried upstream.
+    assert _FakeClient.calls == []
+
+
+def test_cloud_unavailable_returns_502():
+    _FakeClient.raise_on = {"/ollama/v1/models": httpx.ConnectError("boom")}
+    r = _client().get("/v1/account/providers")
+    assert r.status_code == 502
+    assert r.json()["error"] == "cloud_unavailable"
+
+
+def test_cloud_timeout_returns_502():
+    _FakeClient.raise_on = {"/ollama/v1/models": httpx.TimeoutException("slow")}
+    r = _client().get("/v1/account/providers")
+    assert r.status_code == 502
+    assert r.json()["error"] == "cloud_unavailable"
+
+
+def test_cloud_html_returns_502():
+    _FakeClient.routes = {"/ollama/v1/models": {"status": 200, "payload": ValueError("<!doctype")}}
+    r = _client().get("/v1/account/providers")
+    assert r.status_code == 502
+    assert r.json()["error"] == "cloud_unavailable"
+
+
+def test_cloud_upstream_500_returns_502():
+    _FakeClient.routes = {"/ollama/v1/models": {"status": 500, "payload": {"detail": "boom"}}}
+    r = _client().get("/v1/account/providers")
+    assert r.status_code == 502
+    assert r.json()["error"] == "cloud_unavailable"
+
+
+def test_expired_token_upstream_401_reads_as_unlinked():
+    _FakeClient.routes = {"/ollama/v1/models": {"status": 401, "payload": {"detail": "expired"}}}
+    r = _client().get("/v1/account/providers")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["linked"] is False
+    assert body["providers"] == []
+
+
+def test_linked_but_no_shared_backends_returns_empty():
+    # Only a route alias + cloud catalog model, nothing shared_device.
+    _FakeClient.routes = {
+        "/ollama/v1/models": {"status": 200, "payload": {"data": [
+            {"id": "ollabridge:auto", "owned_by": "ollabridge-addon", "x_source": "route_alias"},
+            {"id": "llama3", "owned_by": "ollama", "x_source": "cloud_catalog"},
+        ]}},
+        "/v1/devices": {"status": 200, "payload": []},
+    }
+    r = _client().get("/v1/account/providers")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is True and body["linked"] is True
+    assert body["providers"] == []
+
+
+# ── Grouping + enrichment ────────────────────────────────────────────────────
+
+def test_shared_device_models_grouped_into_provider_with_device_metadata():
+    _FakeClient.routes = {
+        "/ollama/v1/models": {"status": 200, "payload": {"data": [
+            {"id": "llama3:8b", "owned_by": "relay:dev-123", "x_source": "shared_device"},
+            {"id": "qwen2:7b", "owned_by": "relay:dev-123", "x_source": "shared_device"},
+            {"id": "ollabridge:auto", "owned_by": "ollabridge-addon", "x_source": "route_alias"},
+        ]}},
+        "/v1/devices": {"status": 200, "payload": [
+            {"id": "dev-123", "name": "Gaming PC", "online": True},
+        ]},
+    }
+    r = _client().get("/v1/account/providers")
+    assert r.status_code == 200
+    providers = r.json()["providers"]
+    assert len(providers) == 1
+    p = providers[0]
+    assert p["id"] == "ollabridge:dev-123:ollama"
+    assert p["label"] == "Ollama — Gaming PC (OllaBridge)"
+    assert p["origin"] == "ollabridge"
+    assert p["backend"] == "ollama"
+    assert p["capability"] == "chat"
+    assert p["online"] is True
+    assert p["modelCount"] == 2
+    assert p["nodeId"] == "dev-123"
+
+
+def test_offline_device_flag_is_honored():
+    _FakeClient.routes = {
+        "/ollama/v1/models": {"status": 200, "payload": {"data": [
+            {"id": "llama3:8b", "owned_by": "relay:dev-9", "x_source": "shared_device"},
+        ]}},
+        "/v1/devices": {"status": 200, "payload": [
+            {"id": "dev-9", "name": "Home GPU", "online": False},
+        ]},
+    }
+    providers = _client().get("/v1/account/providers").json()["providers"]
+    assert providers[0]["online"] is False
+    assert providers[0]["label"] == "Ollama — Home GPU (OllaBridge)"
+
+
+def test_devices_404_falls_back_to_device_id_and_online_default():
+    # /v1/devices 404 (device sharing disabled) → name falls back to the id and
+    # an advertising device is treated as online.
+    _FakeClient.routes = {
+        "/ollama/v1/models": {"status": 200, "payload": {"data": [
+            {"id": "llama3:8b", "owned_by": "relay:dev-abc", "x_source": "shared_device"},
+        ]}},
+        "/v1/devices": {"status": 404, "payload": {"detail": "Device sharing is not enabled"}},
+    }
+    providers = _client().get("/v1/account/providers").json()["providers"]
+    assert len(providers) == 1
+    assert providers[0]["nodeId"] == "dev-abc"
+    assert providers[0]["label"] == "Ollama — dev-abc (OllaBridge)"
+    assert providers[0]["online"] is True
+
+
+def test_explicit_device_id_field_preferred_over_owned_by():
+    _FakeClient.routes = {
+        "/ollama/v1/models": {"status": 200, "payload": {"data": [
+            {"id": "m1", "device_id": "dev-explicit", "owned_by": "relay:ignored",
+             "x_source": "shared_device"},
+        ]}},
+        "/v1/devices": {"status": 200, "payload": []},
+    }
+    providers = _client().get("/v1/account/providers").json()["providers"]
+    assert providers[0]["nodeId"] == "dev-explicit"
+
+
+def test_legacy_source_field_also_recognized():
+    # Some responses use "source" rather than "x_source".
+    _FakeClient.routes = {
+        "/ollama/v1/models": {"status": 200, "payload": {"data": [
+            {"id": "m1", "owned_by": "relay:dev-1", "source": "shared_device"},
+        ]}},
+        "/v1/devices": {"status": 200, "payload": []},
+    }
+    providers = _client().get("/v1/account/providers").json()["providers"]
+    assert len(providers) == 1 and providers[0]["nodeId"] == "dev-1"
+
+
+def test_multiple_devices_produce_multiple_providers():
+    _FakeClient.routes = {
+        "/ollama/v1/models": {"status": 200, "payload": {"data": [
+            {"id": "a", "owned_by": "relay:dev-1", "x_source": "shared_device"},
+            {"id": "b", "owned_by": "relay:dev-2", "x_source": "shared_device"},
+            {"id": "c", "owned_by": "relay:dev-2", "x_source": "shared_device"},
+        ]}},
+        "/v1/devices": {"status": 200, "payload": [
+            {"id": "dev-1", "name": "One", "online": True},
+            {"id": "dev-2", "name": "Two", "online": True},
+        ]},
+    }
+    providers = _client().get("/v1/account/providers").json()["providers"]
+    by_node = {p["nodeId"]: p for p in providers}
+    assert set(by_node) == {"dev-1", "dev-2"}
+    assert by_node["dev-1"]["modelCount"] == 1
+    assert by_node["dev-2"]["modelCount"] == 2
+
+
+def test_bare_list_model_payload_supported():
+    # Cloud may return a bare list rather than {"data": [...]}.
+    _FakeClient.routes = {
+        "/ollama/v1/models": {"status": 200, "payload": [
+            {"id": "m1", "owned_by": "relay:dev-1", "x_source": "shared_device"},
+        ]},
+        "/v1/devices": {"status": 200, "payload": []},
+    }
+    providers = _client().get("/v1/account/providers").json()["providers"]
+    assert len(providers) == 1
+
+
+# ── Security ─────────────────────────────────────────────────────────────────
+
+def test_token_never_leaks_to_client():
+    _FakeClient.routes = {
+        "/ollama/v1/models": {"status": 200, "payload": {"data": []}},
+        "/v1/devices": {"status": 200, "payload": []},
+    }
+    r = _client().get("/v1/account/providers")
+    assert "operator-token" not in r.text
+    assert "authorization" not in {k.lower() for k in r.headers}
+    # But the server DID attach the bearer upstream.
+    auths = [h.get("Authorization") for _, _, h in _FakeClient.calls]
+    assert "Bearer operator-token" in auths
+
+
+def test_per_user_token_isolates_tenants(monkeypatch):
+    # user-2's own registered token must be used, not the operator fallback.
+    monkeypatch.setattr(ap, "_require_user", lambda a, c: {"id": "user-2"})
+    mp.register_cloud_token("user-2", "user-2-token")
+    _FakeClient.routes = {
+        "/ollama/v1/models": {"status": 200, "payload": {"data": []}},
+        "/v1/devices": {"status": 200, "payload": []},
+    }
+    _client().get("/v1/account/providers")
+    auths = [h.get("Authorization") for _, _, h in _FakeClient.calls]
+    assert all(a == "Bearer user-2-token" for a in auths)
+    assert "Bearer operator-token" not in auths
+
+
+def test_response_is_not_cached():
+    _FakeClient.routes = {
+        "/ollama/v1/models": {"status": 200, "payload": {"data": []}},
+        "/v1/devices": {"status": 200, "payload": []},
+    }
+    r = _client().get("/v1/account/providers")
+    assert r.headers["cache-control"] == "no-store"

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -35,6 +35,17 @@ COPY frontend/ ./
 # WORKDIR is /build, so ../packages must be present at /packages. These are
 # TS source, not npm deps — npm ci above is unchanged.
 COPY packages/ /packages/
+# Frontend build-time flags (Vite bakes ``import.meta.env.VITE_*`` at build).
+# Empty defaults preserve today's behavior (all OFF); pass build-args to opt in.
+#   VITE_ACCOUNTS_UX=1        → mount the OllaBridge account/computers UX
+#   VITE_BFF_SESSION=1        → browser stops storing the cloud token (BFF)
+#   VITE_OLLABRIDGE_CLOUD_URL → cloud host (defaults to app.ollabridge.com)
+ARG VITE_ACCOUNTS_UX=""
+ARG VITE_BFF_SESSION=""
+ARG VITE_OLLABRIDGE_CLOUD_URL=""
+ENV VITE_ACCOUNTS_UX=${VITE_ACCOUNTS_UX} \
+    VITE_BFF_SESSION=${VITE_BFF_SESSION} \
+    VITE_OLLABRIDGE_CLOUD_URL=${VITE_OLLABRIDGE_CLOUD_URL}
 RUN npm run build
 
 # ============================================================

--- a/desktop/docker-manager.js
+++ b/desktop/docker-manager.js
@@ -32,7 +32,7 @@ const SIDECAR_FULL_IMAGE = `${SIDECAR_IMAGE}:${SIDECAR_TAG}`;
 const SIDECAR_CONTAINER = "ollabridge-local";
 const SIDECAR_PORT = 11435; // `ollabridge start` canonical port (dashboard at /ui)
 const NETWORK_NAME = "homepilot-local";
-const DEFAULT_CLOUD_URL = "https://ruslanmv-ollabridge.hf.space";
+const DEFAULT_CLOUD_URL = "https://app.ollabridge.com";
 
 class DockerManager extends EventEmitter {
   constructor() {

--- a/docs/OLLABRIDGE.md
+++ b/docs/OLLABRIDGE.md
@@ -137,7 +137,7 @@ Resolved by the backend at startup and exposed to the frontend:
 ```bash
 GET /v1/edition
 → { "edition": "web", "is_web": true, "is_local": false,
-    "can_provide_gpu": false, "cloud_url": "https://ruslanmv-ollabridge.hf.space" }
+    "can_provide_gpu": false, "cloud_url": "https://app.ollabridge.com" }
 ```
 
 The UI **fails safe to web** while loading, so provider/GPU controls never leak
@@ -216,7 +216,7 @@ telemetry-by-default posture.
 | Variable | Side | Default | Purpose |
 |---|---|---|---|
 | `HOMEPILOT_EDITION` | HomePilot | auto (`web` if Space, else `local`) | Force the edition |
-| `OLLABRIDGE_CLOUD_URL` | HomePilot + sidecar | `https://ruslanmv-ollabridge.hf.space` | Canonical Cloud base URL |
+| `OLLABRIDGE_CLOUD_URL` | HomePilot + sidecar | `https://app.ollabridge.com` | Canonical Cloud base URL |
 | `OLLABRIDGE_CLOUD_TOKEN` | HomePilot | — | Token for cloud-compute (consumer burst) |
 | `OLLABRIDGE_LOCAL_URL` | HomePilot | `http://127.0.0.1:11435` | Where to probe the sidecar |
 | `OLLABRIDGE_NODE_GEN_ENABLED` | sidecar | `false` | Advertise GPU + run ComfyUI image/video jobs |
@@ -225,7 +225,7 @@ telemetry-by-default posture.
 | `OLLABRIDGE_HOMEPILOT_URL` | sidecar | `http://127.0.0.1:8001` | HomePilot backend the node serves |
 | `VITE_OLLABRIDGE_CLOUD_URL` | web build | (default above) | Frontend Cloud URL override |
 
-**Canonical production Cloud URL:** `https://ruslanmv-ollabridge.hf.space`
+**Canonical production Cloud URL:** `https://app.ollabridge.com`
 (override per-deployment with the env vars above).
 
 ---

--- a/docs/PRODUCTION.md
+++ b/docs/PRODUCTION.md
@@ -19,7 +19,7 @@ Companion docs:
 
 | Capability | State | How it's enabled |
 |---|---|---|
-| **OllaBridge Cloud** (control plane) | ✅ live | Hugging Face Space **`ruslanmv/ollabridge`** → `https://ruslanmv-ollabridge.hf.space` (verified RUNNING). |
+| **OllaBridge Cloud** (control plane) | ✅ live | Hugging Face Space **`ruslanmv/ollabridge`** → `https://app.ollabridge.com` (verified RUNNING). |
 | **Mobile Android APK** | ✅ CI-built | `.github/workflows/mobile.yml` → APK attached to each GitHub Release (verified installable: aapt badging + apksigner). |
 | **Mobile sign-in** (MB7) | ✅ | `POST /v1/auth/login` (cloud) → JWT in `expo-secure-store`. |
 | **Streaming chat** (MB1) | ✅ | `POST /v1/chat/completions` — no new route. |
@@ -103,7 +103,7 @@ premium-only with two flags.
 
 ```bash
 HOMEPILOT_COMPUTE_MODE=auto                       # local | ollabridge_cloud | auto
-OLLABRIDGE_CLOUD_URL=https://ruslanmv-ollabridge.hf.space
+OLLABRIDGE_CLOUD_URL=https://app.ollabridge.com
 OLLABRIDGE_CLOUD_TOKEN=                            # Bearer JWT / ob_ API key
 
 # Make the burst premium-only (both default false → everyone can burst):
@@ -121,7 +121,7 @@ by `backend/tests/test_compute_burst.py`.
 
 ## 5. The control plane (OllaBridge Cloud on Hugging Face)
 
-The cloud is **live** at `https://ruslanmv-ollabridge.hf.space` (Space
+The cloud is **live** at `https://app.ollabridge.com` (Space
 `ruslanmv/ollabridge`). Mobile and backend default to this URL
 (`apps/mobile/src/lib/client.ts` `DEFAULT_CLOUD_URL`, `backend/app/config.py`
 `OLLABRIDGE_CLOUD_URL`), so a fresh install needs only a sign-in.

--- a/frontend/src/ui/SettingsPanel.tsx
+++ b/frontend/src/ui/SettingsPanel.tsx
@@ -39,6 +39,7 @@ import {
   onActiveTtsEngineChange,
 } from "./tts";
 import { resolveBackendUrl } from "./lib/backendUrl";
+import { fetchApiJson } from "./lib/apiFetch";
 import {
   getModelSettings,
   getPresetDescription,
@@ -523,8 +524,7 @@ export default function SettingsPanel({
     setLoadingProviders(true);
     setProvidersErr(null);
     try {
-      const res = await fetch(`${resolveBackendUrl(value.backendUrl)}/providers`);
-      const data = await res.json();
+      const data = await fetchApiJson(`${resolveBackendUrl(value.backendUrl)}/providers`);
       if (!data.ok) throw new Error(data.message || "Failed to load providers");
       setProviders(data.providers || {});
     } catch (e: any) {
@@ -541,9 +541,11 @@ export default function SettingsPanel({
     setModelsErr((m) => ({ ...m, [stateKey]: null }));
     try {
       const base = baseUrlOverride || providers?.[providerKey]?.base_url || "";
-      const url = `${value.backendUrl}/models?provider=${encodeURIComponent(providerKey)}&base_url=${encodeURIComponent(base)}${modelType ? `&model_type=${encodeURIComponent(modelType)}` : ''}`;
-      const res = await fetch(url);
-      const data = await res.json();
+      // Resolve the backend URL consistently: interpolating an empty
+      // ``value.backendUrl`` here would produce a relative ``/models`` request
+      // that SPA-falls-back to index.html and reproduces the JSON parse error.
+      const url = `${resolveBackendUrl(value.backendUrl)}/models?provider=${encodeURIComponent(providerKey)}&base_url=${encodeURIComponent(base)}${modelType ? `&model_type=${encodeURIComponent(modelType)}` : ''}`;
+      const data = await fetchApiJson(url);
       if (!data.ok) throw new Error(data.message || "Failed to fetch models");
       setModels((prev) => ({ ...prev, [stateKey]: data.models || [] }));
       if (!data.models || data.models.length === 0) {
@@ -580,7 +582,7 @@ export default function SettingsPanel({
       // Fetch all preset levels in parallel
       await Promise.all(
         presetLevels.map(async (preset) => {
-          const url = `${value.backendUrl}/video-presets?model=${encodeURIComponent(modelType)}&preset=${preset}`;
+          const url = `${resolveBackendUrl(value.backendUrl)}/video-presets?model=${encodeURIComponent(modelType)}&preset=${preset}`;
           const res = await fetch(url);
           const data = await res.json();
           if (data.ok && data.values) {

--- a/frontend/src/ui/lib/apiFetch.test.ts
+++ b/frontend/src/ui/lib/apiFetch.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Step-1 hotfix regression tests for the Settings API fetch guard.
+ *
+ * The reported "Unexpected token '<', "<!doctype "... is not valid JSON" error
+ * came from parsing the SPA's index.html as JSON when a Settings API route was
+ * not forwarded to the backend. fetchApiJson must turn that into an actionable
+ * message and never throw a raw JSON.parse error.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchApiJson } from "./apiFetch";
+
+function mockFetch(res: { ok?: boolean; status?: number; contentType?: string; body?: unknown }) {
+  const headers = new Headers();
+  if (res.contentType) headers.set("content-type", res.contentType);
+  const ok = res.ok ?? true;
+  const status = res.status ?? (ok ? 200 : 500);
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({
+      ok,
+      status,
+      headers,
+      json: async () => {
+        if (res.body === undefined) throw new SyntaxError("Unexpected token '<'");
+        return res.body;
+      },
+    })),
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("fetchApiJson", () => {
+  it("returns parsed JSON on a normal application/json response", async () => {
+    mockFetch({ ok: true, status: 200, contentType: "application/json", body: { ok: true, providers: {} } });
+    await expect(fetchApiJson("https://homepilot.ruslanmv.com/providers")).resolves.toEqual({
+      ok: true,
+      providers: {},
+    });
+  });
+
+  it("throws an actionable deployment message when HTML is returned (SPA fallback)", async () => {
+    mockFetch({ ok: true, status: 200, contentType: "text/html; charset=utf-8" });
+    await expect(fetchApiJson("https://homepilot.ruslanmv.com/providers")).rejects.toThrow(
+      /providers API is unavailable on this deployment/i,
+    );
+  });
+
+  it("never surfaces a raw JSON parse error for an HTML body", async () => {
+    mockFetch({ ok: true, status: 200, contentType: "text/html" });
+    await expect(fetchApiJson("https://homepilot.ruslanmv.com/models")).rejects.not.toThrow(
+      /Unexpected token/i,
+    );
+  });
+
+  it("surfaces the JSON error message on a non-OK JSON response", async () => {
+    mockFetch({ ok: false, status: 502, contentType: "application/json", body: { message: "cloud down" } });
+    await expect(fetchApiJson("https://homepilot.ruslanmv.com/providers")).rejects.toThrow("cloud down");
+  });
+
+  it("includes the HTTP status when a non-JSON error has no body message", async () => {
+    mockFetch({ ok: false, status: 404, contentType: "text/plain" });
+    await expect(fetchApiJson("https://homepilot.ruslanmv.com/providers")).rejects.toThrow(/HTTP 404/);
+  });
+});

--- a/frontend/src/ui/lib/apiFetch.ts
+++ b/frontend/src/ui/lib/apiFetch.ts
@@ -1,0 +1,46 @@
+/**
+ * JSON-safe fetch for HomePilot Settings API routes.
+ *
+ * Fetches a HomePilot API route and returns its parsed JSON, failing with an
+ * actionable message instead of a raw ``Unexpected token '<', "<!doctype "…``
+ * when a deployment serves the SPA ``index.html`` fallback where JSON was
+ * expected.
+ *
+ * On ``homepilot.ruslanmv.com`` the frontend is served same-origin with the
+ * backend, so a Settings API path that isn't forwarded to FastAPI (or a
+ * relative request produced by an empty backend URL) resolves to the SPA
+ * document. Parsing that as JSON is exactly what surfaced the confusing
+ * ``Unexpected token '<'`` error in Settings → Providers. Checking the
+ * content type first turns that into a clear deployment-routing message.
+ */
+export async function fetchApiJson(url: string): Promise<any> {
+  const res = await fetch(url);
+  const ctype = res.headers.get("content-type") || "";
+  if (!ctype.includes("application/json")) {
+    let path = url;
+    try {
+      const origin = typeof window !== "undefined" ? window.location.origin : "http://localhost";
+      path = new URL(url, origin).pathname;
+    } catch {
+      /* keep the raw url */
+    }
+    throw new Error(
+      `The HomePilot providers API is unavailable on this deployment ` +
+        `(HTTP ${res.status}). The request for ${path} returned ` +
+        `${ctype || "an unknown content type"} instead of JSON — check that ` +
+        `this route is forwarded to the backend and not the SPA fallback.`,
+    );
+  }
+  if (!res.ok) {
+    // A proper JSON error body — surface its message rather than a bare status.
+    let detail = `HTTP ${res.status}`;
+    try {
+      const body = await res.json();
+      detail = body?.message || body?.detail || detail;
+    } catch {
+      /* fall back to the HTTP status */
+    }
+    throw new Error(detail);
+  }
+  return res.json();
+}


### PR DESCRIPTION
Make the hosted web edition's OllaBridge account features configurable
from GitHub so an Oracle deploy comes up wired correctly.

Backend runtime (oracle.yml): pass OLLABRIDGE_CLOUD_URL,
OLLABRIDGE_CLOUD_TOKEN (optional), HOMEPILOT_MIRROR_BFF_ENABLED,
HOMEPILOT_BFF_SESSION_ENABLED and HOMEPILOT_ACCOUNT_PROVIDERS_ENABLED
from the oracle-production environment into the generated .env (consumed
by docker-compose env_file). The three flags default ON and the cloud
URL defaults to the canonical host, so remote providers work out of the
box; set the matching variable to "false" to disable. The cloud token is
written only when provided.

Frontend build-time (container/Dockerfile + container.yml): add
VITE_ACCOUNTS_UX, VITE_BFF_SESSION and VITE_OLLABRIDGE_CLOUD_URL as
build-args with empty defaults (today's behavior preserved), fed from
repository variables. Setting the repo variable bakes the flag into the
published image for every deployment that uses it.