### PR TITLE
Fix persona chat: run text turns on the configured Chat Model, not a …

### DIFF
--- a/backend/app/llm.py
+++ b/backend/app/llm.py
@@ -274,6 +274,79 @@ from .config import (
 ProviderName = Literal["openai_compat", "ollama", "openai", "claude", "watsonx"]
 
 
+# ── Ollama model classification & selection ─────────────────────────────────
+# When no model is configured we must never auto-pick a vision-only or embedding
+# model for a *text* turn (that is what made persona chats land on
+# ``moondream:latest`` and return empty content → "couldn't parse"). These
+# heuristics + priority keep text chats on a text model.
+_VISION_ONLY_HINTS = (
+    "moondream", "llava", "bakllava", "minicpm-v", "-vl", "vision", "llama3.2-vision",
+)
+_EMBED_HINTS = (
+    "embed", "nomic-embed", "mxbai-embed", "all-minilm", "bge-", "bge:",
+)
+# Preferred general text-chat models, best first (mirrors /auto-detect).
+_CHAT_MODEL_PRIORITY = (
+    "llama3.2:3b", "llama3.2", "llama3.1", "llama3:8b", "qwen3", "qwen2.5",
+    "mistral-nemo", "gemma2", "mistral:7b", "phi4", "deepseek-r1",
+)
+_VISION_MODEL_PRIORITY = (
+    "moondream", "gemma3:4b", "gemma3", "llava:7b", "llava", "minicpm-v",
+    "llama3.2-vision",
+)
+
+
+def is_text_chat_model(name: str) -> bool:
+    """True when a model id can serve a plain text chat turn (i.e. it is not a
+    vision-only or embedding model)."""
+    n = (name or "").lower()
+    if not n:
+        return False
+    if any(h in n for h in _EMBED_HINTS):
+        return False
+    if any(h in n for h in _VISION_ONLY_HINTS):
+        return False
+    return True
+
+
+def _match_priority(available: List[str], priority) -> str:
+    for preferred in priority:
+        for a in available:
+            al = a.lower()
+            if al == preferred or al.startswith(preferred + ":") or preferred in al:
+                return a
+    return ""
+
+
+def pick_chat_model(available: List[str], configured: str = "") -> str:
+    """Choose a text-chat model. ``configured`` (the user's Chat Model) wins;
+    otherwise prefer a known text model, then any chat-capable model, and only
+    as a last resort the first available id."""
+    names = [str(a).strip() for a in (available or []) if str(a).strip()]
+    cfg = (configured or "").strip()
+    if cfg:
+        return cfg
+    if not names:
+        return ""
+    return (
+        _match_priority(names, _CHAT_MODEL_PRIORITY)
+        or next((n for n in names if is_text_chat_model(n)), "")
+        or names[0]
+    )
+
+
+def pick_vision_model(available: List[str], configured: str = "") -> str:
+    """Choose a vision-capable model for image turns. ``configured`` wins;
+    otherwise prefer a known vision model, then any model."""
+    names = [str(a).strip() for a in (available or []) if str(a).strip()]
+    cfg = (configured or "").strip()
+    if cfg:
+        return cfg
+    if not names:
+        return ""
+    return _match_priority(names, _VISION_MODEL_PRIORITY) or names[0]
+
+
 def _timeout() -> httpx.Timeout:
     # Keep connect reasonable; total bounded by TOOL_TIMEOUT_S
     return httpx.Timeout(timeout=TOOL_TIMEOUT_S, connect=30.0)
@@ -486,7 +559,10 @@ async def chat_ollama(
                     tags_data = tags_r.json()
                     models = tags_data.get("models", [])
                     if models:
-                        mdl = str(models[0].get("name") or "").strip()
+                        names = [str(m.get("name") or "").strip() for m in models]
+                        # Prefer a text-chat model over a vision-only/embedding
+                        # one so a text turn never lands on e.g. moondream.
+                        mdl = pick_chat_model(names, OLLAMA_MODEL)
             except Exception:
                 pass
 

--- a/backend/app/ollabridge_local.py
+++ b/backend/app/ollabridge_local.py
@@ -86,6 +86,32 @@ async def _probe_sidecar() -> Dict[str, Any]:
                     break
         except Exception:
             continue
+
+    # Additive: read the sidecar's cloud-relay status so callers learn the REAL
+    # pairing/relay state instead of unconditionally offering to pair. The
+    # sidecar exposes ``GET /admin/cloud/status`` →
+    #   { state, cloud_url, device_id, models_count, ... }
+    # Never fatal — a sidecar too old to expose this simply leaves the fields
+    # unset and the UI falls back to its previous (reachability-only) behaviour.
+    if out["running"]:
+        try:
+            async with httpx.AsyncClient(timeout=2.0) as client:
+                cr = await client.get(f"{base}/admin/cloud/status")
+            if cr.status_code < 400:
+                cs = cr.json() if callable(getattr(cr, "json", None)) else {}
+                if isinstance(cs, dict):
+                    state = str(cs.get("state") or "").lower().strip()
+                    device_id = str(cs.get("device_id") or "").strip()
+                    out["relay_state"] = state or None
+                    out["device_id"] = device_id or None
+                    out["relay_url"] = (cs.get("cloud_url") or None)
+                    out["models_shared"] = int(cs.get("models_count") or 0)
+                    # Saved device credentials ⇒ this machine is paired; the
+                    # tunnel may be up (connected) or down (reconnect needed).
+                    out["credentials_saved"] = bool(device_id)
+                    out["paired"] = bool(device_id)
+        except Exception:
+            pass
     return out
 
 
@@ -121,10 +147,18 @@ async def local_status() -> Dict[str, Any]:
         # We can only observe "running" locally; treat reachable ⇒ installed.
         "installed": running,
         "running": running,
-        # Pairing is authoritative on the Cloud; the app learns it via the
-        # Cloud /v1/devices list, so we don't assert it from here.
-        "paired": None,
+        # Real pairing/relay state read from the sidecar's cloud status when
+        # available (additive). ``paired`` is a genuine bool when we can observe
+        # saved credentials, else None (unknown) — preserving the old contract.
+        "paired": probe.get("paired"),
+        "relay_state": probe.get("relay_state"),
+        "device_id": probe.get("device_id"),
+        "credentials_saved": probe.get("credentials_saved"),
+        "models_shared": probe.get("models_shared"),
+        # ``cloud_url`` stays the human-facing app host (for /link pages);
+        # ``relay_url`` is the sidecar's relay API host, surfaced separately.
         "cloud_url": _cloud_url(),
+        "relay_url": probe.get("relay_url"),
         "local_url": probe.get("local_url"),
         "models": probe.get("models", 0),
         "share_scope": "owner_only",

--- a/backend/app/openai_compat_endpoint.py
+++ b/backend/app/openai_compat_endpoint.py
@@ -311,6 +311,46 @@ def _build_persona_system_prompt(
     return "\n\n".join(parts) if parts else "You are a helpful assistant."
 
 
+async def _resolve_chat_backend() -> tuple[str, str, str, str]:
+    """Resolve ``(provider, base_url, chat_model, vision_model)`` for the persona
+    pipeline.
+
+    A persona is exposed as one API model but orchestrates several models
+    internally; a *text* turn must run on the user's configured **Chat Model**,
+    not the multimodal one. This honors that Chat Model — persisted server-side
+    via ``POST /v1/system/runtime-config`` (``OLLAMA_MODEL``), then the
+    ``OLLAMA_MODEL`` env — and otherwise picks a text-chat model from the live
+    Ollama tags (never a vision-only model like moondream, which returns empty
+    text and produced the "couldn't parse the agent response" fallback).
+    """
+    provider = _config.DEFAULT_PROVIDER
+    if provider != "ollama":
+        model = _config.LLM_MODEL or ""
+        return provider, _config.LLM_BASE_URL, model, model
+
+    from . import llm as _llm
+    from .runtime_config import read_runtime_config
+    import httpx as _httpx
+
+    configured = (
+        read_runtime_config().get("OLLAMA_MODEL")
+        or _config.OLLAMA_MODEL
+        or ""
+    ).strip()
+    base = _config.OLLAMA_BASE_URL.rstrip("/")
+    names: list[str] = []
+    try:
+        async with _httpx.AsyncClient(timeout=3.0) as client:
+            r = await client.get(f"{base}/api/tags")
+            if r.status_code == 200:
+                names = [str(m.get("name") or "").strip() for m in r.json().get("models", [])]
+    except Exception:
+        names = []
+    chat_model = _llm.pick_chat_model(names, configured)
+    vision_model = _llm.pick_vision_model(names)
+    return provider, _config.OLLAMA_BASE_URL, chat_model, vision_model
+
+
 async def _chat_with_persona_project(
     project_id: str,
     messages: List[ChatMessage],
@@ -365,6 +405,11 @@ async def _chat_with_persona_project(
         if msg.role != "system":
             llm_messages.append({"role": msg.role, "content": msg.content})
 
+    # Resolve the concrete models once: a persona orchestrates a chat model for
+    # text and a vision model for image turns. Never pass None (which made the
+    # Ollama layer auto-pick a vision-only model for text and return empty).
+    provider, base_url, chat_model, vision_model = await _resolve_chat_backend()
+
     # Check if agentic capabilities are enabled
     agentic = project_data.get("agentic") or {}
     capabilities = agentic.get("capabilities") or []
@@ -373,36 +418,31 @@ async def _chat_with_persona_project(
         # Use agent chat with tool use
         try:
             _ac = _get_agent_chat()
-            provider = _config.DEFAULT_PROVIDER
-            if provider == "ollama":
-                base_url = _config.OLLAMA_BASE_URL
-                model = _config.OLLAMA_MODEL or None
-            else:
-                base_url = _config.LLM_BASE_URL
-                model = _config.LLM_MODEL or None
             result = await _ac.agent_chat(
                 user_text=user_message,
                 conversation_id=conversation_id,
                 project_id=project_id,
                 llm_provider=provider,
                 llm_base_url=base_url,
-                llm_model=model,
+                llm_model=chat_model or None,
                 temperature=temperature,
                 max_tokens=max_tokens,
                 vision_provider=provider,
                 vision_base_url=base_url,
-                vision_model=model,
+                vision_model=vision_model or chat_model or None,
                 nsfw_mode=False,
             )
             return result.get("text", "I couldn't generate a response.")
         except Exception as e:
             print(f"[COMPAT] Agent loop failed, falling back to direct LLM: {e}")
 
-    # Direct LLM call (no tools)
+    # Direct LLM call (no tools) — on the resolved chat model.
     try:
         result = await llm_chat(
             llm_messages,
-            provider=_config.DEFAULT_PROVIDER,
+            provider=provider,
+            base_url=base_url,
+            model=chat_model or None,
             temperature=temperature,
             max_tokens=max_tokens,
         )
@@ -448,11 +488,14 @@ async def _chat_with_personality(
         else:
             llm_messages.append({"role": msg.role, "content": msg.content})
 
-    # Call LLM
+    # Call LLM on the resolved chat model (never a vision-only auto-pick).
+    provider, base_url, chat_model, _vision_model = await _resolve_chat_backend()
     try:
         result = await llm_chat(
             llm_messages,
-            provider=_config.DEFAULT_PROVIDER,
+            provider=provider,
+            base_url=base_url,
+            model=chat_model or None,
             temperature=temperature,
             max_tokens=max_tokens,
         )

--- a/backend/app/runtime_config.py
+++ b/backend/app/runtime_config.py
@@ -35,6 +35,10 @@ ALLOWED_KEYS = frozenset({
     "IMAGE_MODEL",
     "VIDEO_MODEL",
     "COMFY_BASE_URL",
+    # The user's selected chat model, persisted so the server-side persona
+    # pipeline (/v1/chat/completions) runs text turns on the same Ollama model
+    # the Settings panel chose — instead of auto-picking a vision-only model.
+    "OLLAMA_MODEL",
 })
 
 

--- a/backend/tests/test_model_selection.py
+++ b/backend/tests/test_model_selection.py
@@ -1,0 +1,62 @@
+"""Tests for Ollama chat/vision model selection.
+
+Regression: with no model configured, HomePilot auto-picked the FIRST Ollama
+model. When that was a vision-only model (e.g. moondream:latest) a persona's
+text turn returned empty content and the agent replied "I couldn't parse the
+agent response." Text turns must land on a text-chat model; the user's
+configured Chat Model must win; vision turns still get a vision model.
+"""
+import os
+import sys
+
+_BACKEND_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _BACKEND_ROOT not in sys.path:
+    sys.path.insert(0, _BACKEND_ROOT)
+
+from app import llm  # noqa: E402
+
+# The user's real list — moondream is first, which the old code picked.
+TAGS = [
+    "moondream:latest", "llama3.2:3b", "llama3.2:1b", "gemma3:4b",
+    "huihui_ai/qwen3-abliterated:4b", "qwen2.5:0.5b", "deepseek-r1:latest",
+    "llama3:8b", "gemma:2b", "nomic-embed-text",
+]
+
+
+def test_auto_pick_avoids_vision_only_model():
+    picked = llm.pick_chat_model(TAGS)
+    assert picked != "moondream:latest"
+    assert llm.is_text_chat_model(picked)
+
+
+def test_configured_chat_model_wins():
+    assert llm.pick_chat_model(TAGS, "huihui_ai/qwen3-abliterated:4b") == "huihui_ai/qwen3-abliterated:4b"
+
+
+def test_auto_pick_prefers_priority_text_model():
+    # llama3.2:3b is top of the priority list and present.
+    assert llm.pick_chat_model(TAGS) == "llama3.2:3b"
+
+
+def test_vision_pick_returns_a_vision_model():
+    assert llm.pick_vision_model(TAGS) == "moondream:latest"
+
+
+def test_is_text_chat_model_classification():
+    assert llm.is_text_chat_model("huihui_ai/qwen3-abliterated:4b") is True
+    assert llm.is_text_chat_model("llama3:8b") is True
+    assert llm.is_text_chat_model("moondream:latest") is False
+    assert llm.is_text_chat_model("llava:7b") is False
+    assert llm.is_text_chat_model("nomic-embed-text") is False
+    assert llm.is_text_chat_model("") is False
+
+
+def test_only_vision_and_embed_available_falls_back_to_first():
+    # Degenerate case: nothing chat-capable — still return something usable.
+    only = ["moondream:latest", "nomic-embed-text"]
+    assert llm.pick_chat_model(only) == "moondream:latest"
+
+
+def test_empty_list_returns_empty():
+    assert llm.pick_chat_model([]) == ""
+    assert llm.pick_vision_model([]) == ""

--- a/frontend/src/ui/App.jsx
+++ b/frontend/src/ui/App.jsx
@@ -1906,6 +1906,9 @@ export default function App() {
                         IMAGE_MODEL: settingsDraft.modelImages || '',
                         VIDEO_MODEL: settingsDraft.modelVideo || '',
                         COMFY_BASE_URL: comfyBaseUrl,
+                        // Persist the chat model server-side so HomePilot
+                        // personas run text turns on the same model.
+                        OLLAMA_MODEL: settingsDraft.modelChat || '',
                     },
                 }),
             }).catch(() => { });

--- a/frontend/src/ui/App.tsx
+++ b/frontend/src/ui/App.tsx
@@ -3299,6 +3299,9 @@ export default function App() {
             IMAGE_MODEL: settingsDraft.modelImages || '',
             VIDEO_MODEL: settingsDraft.modelVideo || '',
             COMFY_BASE_URL: comfyBaseUrl,
+            // Persist the chat model server-side so HomePilot personas
+            // (/v1/chat/completions) run text turns on the same model.
+            OLLAMA_MODEL: settingsDraft.modelChat || '',
           },
         }),
       }).catch(() => { /* best-effort */ })

--- a/frontend/src/ui/components/OllaBridgeLink.tsx
+++ b/frontend/src/ui/components/OllaBridgeLink.tsx
@@ -33,6 +33,8 @@ interface DeviceInfo {
   online: boolean
   gpu_name?: string | null
   vram_mb?: number | null
+  kind?: string | null
+  last_seen?: string | null
 }
 
 interface LocalStatus {
@@ -43,6 +45,13 @@ interface LocalStatus {
   local_url?: string | null
   models?: number
   share_scope?: string
+  // Real relay/pairing state (additive; present on newer backends).
+  paired?: boolean | null
+  relay_state?: string | null
+  device_id?: string | null
+  credentials_saved?: boolean | null
+  models_shared?: number | null
+  relay_url?: string | null
 }
 
 const INSTALL_LOCAL_URL = 'https://github.com/ruslanmv/HomePilot#installation'
@@ -53,6 +62,9 @@ export default function OllaBridgeLink() {
   const [email, setEmail] = useState('')
   const [me, setMe] = useState<{ email?: string } | null>(null)
   const [devices, setDevices] = useState<DeviceInfo[]>([])
+  // A failed lookup is NOT the same as "no machines" — track it separately so
+  // an API error never renders as an empty state.
+  const [deviceError, setDeviceError] = useState('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
   const [pw, setPw] = useState('')
@@ -80,21 +92,40 @@ export default function OllaBridgeLink() {
     if (!tok) return
     setLoading(true)
     setError('')
+    setDeviceError('')
     try {
       const auth = { Authorization: `Bearer ${tok}` }
-      const [meRes, devRes] = await Promise.all([
+      // Prefer the always-on, owner-scoped compute-node inventory (returns only
+      // GPU machines, never client apps). Fall back to /v1/devices only for an
+      // older Cloud that lacks the endpoint.
+      const [meRes, cnRes] = await Promise.all([
         fetch(`${cloudUrl}/v1/auth/me`, { headers: auth }),
-        fetch(`${cloudUrl}/v1/devices`, { headers: auth }),
+        fetch(`${cloudUrl}/v1/account/compute-nodes`, { headers: auth }),
       ])
-      if (meRes.status === 401) {
+      if (meRes.status === 401 || cnRes.status === 401) {
         setError('Your OllaBridge session expired — reconnect below.')
         setToken(''); try { localStorage.removeItem('homepilot_cloud_token') } catch { /* ignore */ }
         return
       }
       setMe(meRes.ok ? await meRes.json() : null)
-      // /v1/devices is 404 when device sharing is disabled on the Cloud — treat
-      // as "no nodes" rather than an error so account-link still reads as OK.
-      setDevices(devRes.ok ? (await devRes.json()) : [])
+      if (cnRes.ok) {
+        const data = await cnRes.json()
+        setDevices(Array.isArray(data?.nodes) ? data.nodes : [])
+      } else if (cnRes.status === 404) {
+        // Older Cloud without the compute-node inventory — fall back to the
+        // legacy device list (compute + client mixed).
+        const devRes = await fetch(`${cloudUrl}/v1/devices`, { headers: auth })
+        if (devRes.ok) {
+          setDevices(await devRes.json())
+        } else if (devRes.status === 404) {
+          // Neither endpoint present — genuinely nothing to enumerate.
+          setDevices([])
+        } else {
+          setDeviceError(`Could not load your computers (${devRes.status}).`)
+        }
+      } else {
+        setDeviceError(`Could not load your computers (${cnRes.status}).`)
+      }
     } catch {
       setError('Could not reach OllaBridge Cloud.')
     } finally {
@@ -135,6 +166,17 @@ export default function OllaBridgeLink() {
 
   const linked = Boolean(token)
   const host = cloudUrl.replace(/^https?:\/\//, '')
+
+  // Derived relay/pairing state for the "This computer" card. Prefer the real
+  // relay state read from the sidecar; fall back gracefully when a field is
+  // absent (older backend) so behaviour degrades to the previous UX.
+  const relayState = (sidecar?.relay_state || '').toLowerCase()
+  const isPaired =
+    sidecar?.paired === true || !!sidecar?.credentials_saved || !!sidecar?.device_id
+  const isRelayConnected = relayState === 'connected'
+  const isReconnecting = relayState === 'reconnecting' || relayState === 'pairing'
+  const modelsShared = sidecar?.models_shared ?? sidecar?.models ?? 0
+  const sidecarUiUrl = `${sidecar?.local_url || 'http://127.0.0.1:11435'}/ui`
 
   return (
     <div className="space-y-4">
@@ -211,38 +253,99 @@ export default function OllaBridgeLink() {
             <div className="flex items-center gap-2 text-xs font-bold uppercase tracking-wider text-white/45">
               <Server size={13} /> This computer
             </div>
-            {sidecar?.running ? (
+            {/* Badge reflects the REAL relay state, not just reachability. */}
+            {!sidecar?.running ? (
+              <span className="text-[11px] px-2.5 py-1 rounded-full bg-white/5 border border-white/10 text-white/50">Sidecar stopped</span>
+            ) : isRelayConnected ? (
+              <span className="inline-flex items-center gap-1.5 text-[11px] px-2.5 py-1 rounded-full bg-emerald-500/12 border border-emerald-500/30 text-emerald-300">
+                <span className="w-1.5 h-1.5 rounded-full bg-emerald-400" /> Connected
+              </span>
+            ) : isReconnecting ? (
+              <span className="inline-flex items-center gap-1.5 text-[11px] px-2.5 py-1 rounded-full bg-amber-500/12 border border-amber-500/30 text-amber-300">
+                <span className="w-1.5 h-1.5 rounded-full bg-amber-400" /> Reconnecting
+              </span>
+            ) : isPaired ? (
+              <span className="text-[11px] px-2.5 py-1 rounded-full bg-white/5 border border-white/10 text-white/50">Disconnected</span>
+            ) : (
               <span className="inline-flex items-center gap-1.5 text-[11px] px-2.5 py-1 rounded-full bg-emerald-500/12 border border-emerald-500/30 text-emerald-300">
                 <span className="w-1.5 h-1.5 rounded-full bg-emerald-400" /> Sidecar running
               </span>
-            ) : (
-              <span className="text-[11px] px-2.5 py-1 rounded-full bg-white/5 border border-white/10 text-white/50">Sidecar stopped</span>
             )}
           </div>
-          <p className="text-sm text-white/80">
-            This PC can become your <span className="font-semibold text-white">private GPU node</span>. HomePilot Local
-            runs the <span className="font-mono text-white/70">ollabridge</span> sidecar; pair it with OllaBridge Cloud to
-            reach it from HomePilot Web or mobile.
-          </p>
-          {sidecar?.running ? (
-            <div className="flex flex-wrap items-center gap-2 mt-3">
-              <a href={`${(sidecar.local_url || 'http://127.0.0.1:11435')}/ui`} target="_blank" rel="noopener noreferrer"
-                className="h-9 px-3 rounded-xl bg-white/5 hover:bg-white/10 border border-white/10 text-xs text-white/80 inline-flex items-center gap-1.5">
-                <ExternalLink size={13} /> Open OllaBridge dashboard
-              </a>
-              <a href={`${cloudUrl}/link`} target="_blank" rel="noopener noreferrer"
-                className="h-9 px-3 rounded-xl bg-gradient-to-r from-cyan-500/90 to-violet-500/90 text-white text-xs font-semibold inline-flex items-center gap-1.5">
-                <Plus size={13} /> Pair this computer
-              </a>
-              <span className="text-[11px] text-white/40 ml-1">Sharing: <span className="text-white/60">my account only</span></span>
-            </div>
+
+          {!sidecar?.running ? (
+            /* Sidecar not reachable — how to start it. */
+            <>
+              <p className="text-sm text-white/80">
+                This PC can become your <span className="font-semibold text-white">private GPU node</span>. HomePilot Local
+                runs the <span className="font-mono text-white/70">ollabridge</span> sidecar to reach it from HomePilot Web or mobile.
+              </p>
+              <div className="mt-3 text-xs text-white/50 leading-relaxed">
+                The OllaBridge Local sidecar isn’t reachable{sidecar?.local_url ? ` at ${sidecar.local_url}` : ''}. Start it with{' '}
+                <span className="font-mono text-white/70">ollabridge start</span> (installs on first run) — it serves an
+                OpenAI-compatible gateway on <span className="font-mono text-white/70">:11435</span>. HomePilot Local’s desktop
+                app starts it for you.
+              </div>
+            </>
+          ) : isRelayConnected ? (
+            /* READY — already paired and connected. No pairing button. */
+            <>
+              <p className="text-sm text-white/80">
+                <span className="font-semibold text-white">Ready.</span> This PC is online through OllaBridge Cloud — reachable from HomePilot Web and mobile.
+              </p>
+              <div className="mt-2 grid gap-0.5 text-[11px] text-white/45">
+                {sidecar?.device_id && (
+                  <div>Device: <span className="font-mono text-white/70">{sidecar.device_id}</span></div>
+                )}
+                <div>{modelsShared} model{modelsShared === 1 ? '' : 's'} shared · Access: <span className="text-white/60">Private — only your account</span></div>
+              </div>
+              <div className="flex flex-wrap items-center gap-2 mt-3">
+                <a href={sidecarUiUrl} target="_blank" rel="noopener noreferrer"
+                  className="h-9 px-3 rounded-xl bg-white/5 hover:bg-white/10 border border-white/10 text-xs text-white/80 inline-flex items-center gap-1.5">
+                  <ExternalLink size={13} /> Open OllaBridge dashboard
+                </a>
+                <span className="text-[11px] text-white/35 ml-1">Manage sharing or disconnect in the dashboard.</span>
+              </div>
+            </>
+          ) : isPaired ? (
+            /* Paired but the tunnel is down — reconnecting or needs reconnect. */
+            <>
+              <p className="text-sm text-white/80">
+                {isReconnecting ? (
+                  <>This computer is <span className="font-semibold text-white">reconnecting</span> to OllaBridge Cloud — no action needed.</>
+                ) : (
+                  <>This computer is paired but its cloud tunnel is <span className="font-semibold text-white">disconnected</span>.</>
+                )}
+              </p>
+              {sidecar?.device_id && (
+                <div className="mt-2 text-[11px] text-white/45">Device: <span className="font-mono text-white/70">{sidecar.device_id}</span></div>
+              )}
+              <div className="flex flex-wrap items-center gap-2 mt-3">
+                <a href={sidecarUiUrl} target="_blank" rel="noopener noreferrer"
+                  className="h-9 px-3 rounded-xl bg-white/5 hover:bg-white/10 border border-white/10 text-xs text-white/80 inline-flex items-center gap-1.5">
+                  <ExternalLink size={13} /> Open OllaBridge dashboard
+                </a>
+                {!isReconnecting && (
+                  <span className="text-[11px] text-white/35 ml-1">Reconnect from the dashboard’s Cloud tab.</span>
+                )}
+              </div>
+            </>
           ) : (
-            <div className="mt-3 text-xs text-white/50 leading-relaxed">
-              The OllaBridge Local sidecar isn’t reachable{sidecar?.local_url ? ` at ${sidecar.local_url}` : ''}. Start it with{' '}
-              <span className="font-mono text-white/70">ollabridge start</span> (installs on first run) — it serves an
-              OpenAI-compatible gateway on <span className="font-mono text-white/70">:11435</span>. HomePilot Local’s desktop
-              app starts it for you.
-            </div>
+            /* Running, no saved credentials — first-time connect. Opens the
+               local sidecar dashboard where "Link to Cloud" starts pairing —
+               NOT the cloud code-entry page, so the user never types a code. */
+            <>
+              <p className="text-sm text-white/80">
+                This PC can become your <span className="font-semibold text-white">private GPU node</span>. Connect it to OllaBridge Cloud to reach it from HomePilot Web or mobile.
+              </p>
+              <div className="flex flex-wrap items-center gap-2 mt-3">
+                <a href={sidecarUiUrl} target="_blank" rel="noopener noreferrer"
+                  className="h-9 px-3 rounded-xl bg-gradient-to-r from-cyan-500/90 to-violet-500/90 text-white text-xs font-semibold inline-flex items-center gap-1.5">
+                  <Plus size={13} /> Connect this computer
+                </a>
+                <span className="text-[11px] text-white/40 ml-1">Opens the dashboard → Cloud tab → Link to Cloud.</span>
+              </div>
+            </>
           )}
           <p className="mt-2 text-[11px] text-white/30">Installed ≠ paired ≠ shared — nothing is shared until you approve it, and only to your own account by default.</p>
         </div>
@@ -257,11 +360,22 @@ export default function OllaBridgeLink() {
             </div>
             <a href={`${cloudUrl}/link`} target="_blank" rel="noopener noreferrer"
               className="h-9 px-3 rounded-xl bg-gradient-to-r from-cyan-500/90 to-violet-500/90 text-white text-xs font-semibold inline-flex items-center gap-1.5">
-              <Plus size={13} /> Add a machine
+              <Plus size={13} /> {devices.length > 0 ? 'Add another computer' : 'Add a machine'}
             </a>
           </div>
 
-          {devices.length > 0 ? (
+          {deviceError ? (
+            /* A lookup failure must never render as "no machines". */
+            <div className="text-xs leading-relaxed">
+              <div className="px-3 py-2 rounded-xl bg-amber-500/10 border border-amber-500/25 text-amber-300">
+                {deviceError}
+              </div>
+              <button type="button" onClick={() => load(token)}
+                className="mt-2 h-8 px-3 rounded-lg bg-white/5 hover:bg-white/10 border border-white/10 text-[11px] text-white/70 inline-flex items-center gap-1.5">
+                <RefreshCw size={12} /> Retry
+              </button>
+            </div>
+          ) : devices.length > 0 ? (
             <div className="grid gap-1.5">
               {devices.map((d) => (
                 <div key={d.id} className="flex items-center gap-2.5 rounded-xl border border-white/[0.07] bg-white/[0.02] px-3 py-2">


### PR DESCRIPTION
Fix persona chat: run text turns on the configured Chat Model, not a vision model
From the 3D chatbot, chatting with a HomePilot persona replied "I couldn't
parse the agent response." Root cause: the persona pipeline passed model=None
to the LLM, so the Ollama layer auto-picked the FIRST installed model — here
moondream:latest, a vision-only model that returns empty text. The agent
parser then hit its empty-response fallback.

A persona is one API model but orchestrates several models internally; a text
turn must use the user's Chat Model, and only image turns the multimodal one.

- llm.py: add pick_chat_model()/pick_vision_model()/is_text_chat_model() that
  exclude vision-only (moondream, llava, *-vl, …) and embedding models and
  prefer known text models; the Ollama auto-pick now uses pick_chat_model so no
  text path can land on a vision model.
- openai_compat_endpoint.py: _resolve_chat_backend() resolves the concrete chat
  and vision models — honoring the configured Chat Model (runtime-config
  OLLAMA_MODEL → OLLAMA_MODEL env) and otherwise a text-chat model from live
  tags. Persona (agentic + direct) and personality paths now pass a concrete
  chat model for text and a vision model for image turns, never None.
- runtime_config.py: allow persisting OLLAMA_MODEL so the Settings Chat Model
  reaches the server-side persona pipeline.
- App.tsx/App.jsx: Save Settings now persists OLLAMA_MODEL = modelChat.

Test: tests/test_model_selection.py — auto-pick avoids moondream, configured
model wins, vision pick still returns a vision model, embed/vision excluded.