### PR TITLE
Compute sources routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -722,3 +722,12 @@ Apache-2.0
 </p>
 
 <p align="center"><sub>🎬 Turn your writing into a YouTube video, Short, and teaser — see <a href="docs/YOUTUBE.md">docs/YOUTUBE.md</a>.</sub></p>
+
+<h2 align="center">🖥️ Compute Sources &amp; Routing</h2>
+
+<p align="center">
+  <img src="assets/compute-sources-routing.svg" alt="Compute Sources & Routing — HomePilot's Compute Router binds each model to a target and sends the request over HTTPS to OllaBridge Cloud, which authorizes and relays it over an outbound WebSocket to the GPU worker that executes it (Google Colab running Ollama, RunPod running ComfyUI); local models run on This PC without the relay; tokens stream back, and when a device is offline the request falls back to the local GPU before the first token." width="900" />
+</p>
+
+<p align="center"><sub>Run each model where you choose — this PC, a paired Google Colab / RunPod GPU via OllaBridge Cloud, or a hosted API — with <b>per-model routing</b>, <b>health-aware fallback</b>, cost budgets, and token streaming. HomePilot sends the request to Cloud with routing metadata (model · device · fallback) — never to the worker directly.</sub></p>
+<p align="center"><sub>👉 <b>New here?</b> Follow the beginner step-by-step guide — connect a free Google Colab / RunPod / AWS GPU in minutes: <a href="docs/COMPUTE_PRODUCTION.md">docs/COMPUTE_PRODUCTION.md</a>. Going live? It ends with the production checklist and <code>GET /compute/readiness</code>.</sub></p>

--- a/assets/compute-sources-routing.svg
+++ b/assets/compute-sources-routing.svg
@@ -1,0 +1,140 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 650" role="img"
+     aria-label="Compute Sources and Routing: HomePilot's Compute Router binds each model to a target and sends the request with routing metadata to OllaBridge Cloud, which authorizes and relays it over an outbound WebSocket to the GPU worker that executes it (Google Colab running Ollama, RunPod running ComfyUI); local models run on This PC without the relay; tokens stream back, and when a device is offline the request falls back to the local GPU before the first token.">
+  <title>HomePilot — Compute Sources &amp; Routing</title>
+  <defs>
+    <style>
+      text { font-family: "Segoe UI", Roboto, Helvetica, Arial, sans-serif; }
+      .h    { fill:#f2f4f7; font-weight:700; }
+      .sub  { fill:#8890a0; }
+      .lbl  { fill:#d7dbe3; }
+      .mut  { fill:#7b8494; }
+      .cap  { fill:#9aa2b1; }
+      .kick { fill:#a97cff; font-weight:700; letter-spacing:1.5px; }
+    </style>
+    <radialGradient id="glowV" cx="20%" cy="0%" r="70%">
+      <stop offset="0%" stop-color="#7d3bff" stop-opacity="0.22"/>
+      <stop offset="100%" stop-color="#7d3bff" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="glowC" cx="90%" cy="100%" r="70%">
+      <stop offset="0%" stop-color="#25b8cf" stop-opacity="0.18"/>
+      <stop offset="100%" stop-color="#25b8cf" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="cloudTop" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#46d3e6" stop-opacity="0.14"/>
+      <stop offset="100%" stop-color="#46d3e6" stop-opacity="0"/>
+    </linearGradient>
+    <marker id="aV" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto"><polygon points="0,0 8,3 0,6" fill="#a97cff"/></marker>
+    <marker id="aC" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto"><polygon points="0,0 8,3 0,6" fill="#4dd6e8"/></marker>
+    <marker id="aE" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto"><polygon points="0,0 8,3 0,6" fill="#43d19b"/></marker>
+    <marker id="aA" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto"><polygon points="0,0 8,3 0,6" fill="#f6c453"/></marker>
+  </defs>
+
+  <!-- canvas -->
+  <rect width="1200" height="650" rx="18" fill="#0b0d12"/>
+  <rect width="1200" height="650" rx="18" fill="url(#glowV)"/>
+  <rect width="1200" height="650" rx="18" fill="url(#glowC)"/>
+
+  <!-- header -->
+  <rect x="40" y="34" width="4" height="34" rx="2" fill="#a97cff"/>
+  <text x="56" y="52" class="h" font-size="24">Compute Sources &amp; Routing</text>
+  <text x="56" y="74" class="sub" font-size="13">Per-model routing across local and relay-reached GPU workers — with outbound WSS, health-aware fallback, and token streaming.</text>
+
+  <!-- ===================== HomePilot (orchestrator) ===================== -->
+  <rect x="40" y="104" width="352" height="316" rx="16" fill="#15171d" stroke="#2a2e38"/>
+  <text x="62" y="140" class="h" font-size="17">HomePilot</text>
+  <text x="62" y="160" class="mut" font-size="12">Orchestrator · personas · memory · tools · policy</text>
+
+  <!-- compute router -->
+  <rect x="62" y="176" width="308" height="180" rx="12" fill="#1b1f28" stroke="#2f3441"/>
+  <text x="80" y="200" class="kick" font-size="11">COMPUTE ROUTER</text>
+
+  <!-- route rows: modality pill + model -->
+  <g font-size="13">
+    <rect x="80" y="212" width="46" height="20" rx="10" fill="#a97cff" fill-opacity="0.16" stroke="#a97cff" stroke-opacity="0.5"/>
+    <text x="103" y="226" fill="#c9b3ff" text-anchor="middle" font-size="11" font-weight="700">chat</text>
+    <text x="136" y="226" class="lbl">deepseek-r1:latest</text>
+
+    <rect x="80" y="248" width="46" height="20" rx="10" fill="#4dd6e8" fill-opacity="0.14" stroke="#4dd6e8" stroke-opacity="0.5"/>
+    <text x="103" y="262" fill="#9fe9f3" text-anchor="middle" font-size="11" font-weight="700">image</text>
+    <text x="136" y="262" class="lbl">dreamshaper_8</text>
+
+    <rect x="80" y="284" width="46" height="20" rx="10" fill="#43d19b" fill-opacity="0.14" stroke="#43d19b" stroke-opacity="0.5"/>
+    <text x="103" y="298" fill="#93e7c6" text-anchor="middle" font-size="11" font-weight="700">chat</text>
+    <text x="136" y="298" class="lbl">llama3:8b</text>
+  </g>
+  <line x1="80" y1="320" x2="352" y2="320" stroke="#2f3441"/>
+  <text x="80" y="340" class="mut" font-size="11">explicit route → modality default → global default → safe local tail</text>
+
+  <!-- This PC (local target + fallback destination) -->
+  <rect x="40" y="446" width="236" height="74" rx="14" fill="#0f1a17" stroke="#43d19b" stroke-opacity="0.45"/>
+  <circle cx="62" cy="474" r="5" fill="#43d19b"/>
+  <text x="78" y="479" class="h" font-size="15">This PC</text>
+  <text x="62" y="502" class="mut" font-size="11.5">Local GPU · Ollama / ComfyUI · always available</text>
+
+  <!-- ===================== OllaBridge Cloud (control plane + relay) ===================== -->
+  <rect x="475" y="150" width="250" height="250" rx="16" fill="#15171d" stroke="#2a2e38"/>
+  <rect x="475" y="150" width="250" height="60" rx="16" fill="url(#cloudTop)"/>
+  <text x="497" y="186" class="h" font-size="16">OllaBridge Cloud</text>
+  <text x="497" y="205" class="mut" font-size="11.5">Control plane · secure relay · no inference</text>
+  <g font-size="12.5" class="lbl">
+    <circle cx="503" cy="234" r="3" fill="#4dd6e8"/><text x="516" y="238">Authentication &amp; device pairing</text>
+    <circle cx="503" cy="262" r="3" fill="#4dd6e8"/><text x="516" y="266">Device registry + heartbeat</text>
+    <circle cx="503" cy="290" r="3" fill="#4dd6e8"/><text x="516" y="294">Owner-only routing</text>
+    <circle cx="503" cy="318" r="3" fill="#4dd6e8"/><text x="516" y="322">WebSocket relay</text>
+    <circle cx="503" cy="346" r="3" fill="#4dd6e8"/><text x="516" y="350">Short-lived media cache</text>
+  </g>
+
+  <!-- ===================== GPU workers (execute) ===================== -->
+  <!-- Colab -->
+  <rect x="808" y="150" width="352" height="104" rx="14" fill="#15171d" stroke="#2a2e38"/>
+  <text x="830" y="184" class="h" font-size="15">Google Colab · T4</text>
+  <text x="830" y="205" class="mut" font-size="11.5">Runtime: Ollama · chat / multimodal</text>
+  <text x="830" y="234" class="mut" font-size="11">llama3.2 · gemma3 · moondream</text>
+  <rect x="1028" y="164" width="58" height="20" rx="10" fill="#43d19b" fill-opacity="0.14" stroke="#43d19b" stroke-opacity="0.5"/>
+  <text x="1057" y="178" fill="#93e7c6" text-anchor="middle" font-size="10.5" font-weight="700">Online</text>
+  <rect x="1092" y="164" width="64" height="20" rx="10" fill="#f6c453" fill-opacity="0.12" stroke="#f6c453" stroke-opacity="0.45"/>
+  <text x="1124" y="178" fill="#f3d38a" text-anchor="middle" font-size="10.5" font-weight="700">Ephemeral</text>
+
+  <!-- RunPod -->
+  <rect x="808" y="286" width="352" height="104" rx="14" fill="#15171d" stroke="#2a2e38"/>
+  <text x="830" y="320" class="h" font-size="15">RunPod · RTX 4090</text>
+  <text x="830" y="341" class="mut" font-size="11.5">Runtime: ComfyUI · image / video</text>
+  <text x="830" y="370" class="mut" font-size="11">dreamshaper · flux · ltx-video</text>
+  <rect x="1028" y="300" width="58" height="20" rx="10" fill="#43d19b" fill-opacity="0.14" stroke="#43d19b" stroke-opacity="0.5"/>
+  <text x="1057" y="314" fill="#93e7c6" text-anchor="middle" font-size="10.5" font-weight="700">Online</text>
+
+  <!-- ===================== flows ===================== -->
+  <!-- request: Router -> Cloud (violet) -->
+  <line x1="392" y1="248" x2="469" y2="248" stroke="#a97cff" stroke-width="2" marker-end="url(#aV)"/>
+  <text x="404" y="240" fill="#b79bff" font-size="10.5">HTTPS</text>
+
+  <!-- relay: Cloud -> workers (cyan) -->
+  <path d="M725,208 C 762,208 772,200 806,202" fill="none" stroke="#4dd6e8" stroke-width="2" marker-end="url(#aC)"/>
+  <path d="M725,322 C 762,322 772,334 806,336" fill="none" stroke="#4dd6e8" stroke-width="2" marker-end="url(#aC)"/>
+  <text x="738" y="262" fill="#7fdfec" font-size="10.5">relay</text>
+
+  <!-- outbound WSS: worker connects out to Cloud (dashed cyan) -->
+  <path d="M806,248 C 762,250 736,228 726,206" fill="none" stroke="#4dd6e8" stroke-width="1.6" stroke-dasharray="5 4" marker-end="url(#aC)" opacity="0.9"/>
+  <text x="600" y="126" fill="#7fdfec" font-size="10.5">outbound WSS · no public ports / static IP</text>
+
+  <!-- stream back: Cloud -> HomePilot (cyan) -->
+  <path d="M469,372 C 432,384 408,382 394,376" fill="none" stroke="#4dd6e8" stroke-width="2" marker-end="url(#aC)"/>
+  <text x="404" y="360" fill="#7fdfec" font-size="10.5">◄ stream</text>
+
+  <!-- local route: Router -> This PC (emerald, bypasses cloud) -->
+  <line x1="158" y1="356" x2="158" y2="444" stroke="#43d19b" stroke-width="2" marker-end="url(#aE)"/>
+  <text x="170" y="404" fill="#7bdcb6" font-size="10.5">local — no relay</text>
+
+  <!-- fallback: offline device -> This PC (dashed amber, bottom gutter) -->
+  <path d="M808,252 C 560,600 400,600 278,506" fill="none" stroke="#f6c453" stroke-width="1.8" stroke-dasharray="6 5" marker-end="url(#aA)"/>
+  <text x="543" y="596" fill="#f3d38a" font-size="11" text-anchor="middle">device offline → local fallback (heartbeat expired · before the first token)</text>
+
+  <!-- ===================== legend ===================== -->
+  <g font-size="11" class="cap">
+    <line x1="56" y1="628" x2="86" y2="628" stroke="#a97cff" stroke-width="2"/><text x="92" y="632">request + routing</text>
+    <line x1="228" y1="628" x2="258" y2="628" stroke="#4dd6e8" stroke-width="2"/><text x="264" y="632">relay + stream</text>
+    <line x1="392" y1="628" x2="422" y2="628" stroke="#4dd6e8" stroke-width="1.6" stroke-dasharray="5 4"/><text x="428" y="632">outbound WSS</text>
+    <line x1="560" y1="628" x2="590" y2="628" stroke="#43d19b" stroke-width="2"/><text x="596" y="632">local (no relay)</text>
+    <line x1="720" y1="628" x2="750" y2="628" stroke="#f6c453" stroke-width="1.8" stroke-dasharray="6 5"/><text x="756" y="632">health-aware fallback</text>
+  </g>
+</svg>

--- a/assets/homepilot-connect-illustration.svg
+++ b/assets/homepilot-connect-illustration.svg
@@ -1,0 +1,63 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 940 360" role="img"
+     aria-label="Illustration of HomePilot after connecting a GPU: the Resources tab lists This PC (Online) and Google Colab T4 (Online, Ephemeral, heartbeat 8 seconds ago); beside the deepseek-r1 model, Runs on is set to Colab T4 with Fallback This PC and Status Colab T4 online.">
+  <title>Illustration — what you'll see in HomePilot after connecting a GPU</title>
+  <defs>
+    <style>
+      text { font-family: "Segoe UI", Roboto, Helvetica, Arial, sans-serif; }
+      .h { fill:#f2f4f7; font-weight:700; }
+      .m { fill:#8890a0; }
+      .l { fill:#d7dbe3; }
+      .k { fill:#a97cff; font-weight:700; letter-spacing:1px; }
+    </style>
+  </defs>
+  <rect width="940" height="360" rx="16" fill="#0b0d12"/>
+  <text x="28" y="40" class="k" font-size="12">ILLUSTRATION — WHAT YOU'LL SEE IN HOMEPILOT</text>
+
+  <!-- Resources panel -->
+  <rect x="28" y="56" width="430" height="276" rx="14" fill="#15171d" stroke="#2a2e38"/>
+  <text x="50" y="90" class="h" font-size="16">Settings ›  Compute ›  Resources</text>
+
+  <!-- Sync button -->
+  <rect x="300" y="72" width="140" height="30" rx="9" fill="#4dd6e8" fill-opacity="0.14" stroke="#4dd6e8" stroke-opacity="0.5"/>
+  <text x="370" y="92" fill="#9fe9f3" text-anchor="middle" font-size="12" font-weight="700">☁ Sync from Cloud</text>
+
+  <!-- This PC row -->
+  <rect x="50" y="112" width="386" height="86" rx="12" fill="#0f1a17" stroke="#43d19b" stroke-opacity="0.4"/>
+  <circle cx="72" cy="140" r="5" fill="#43d19b"/>
+  <text x="86" y="145" class="h" font-size="14">This PC</text>
+  <text x="72" y="168" class="m" font-size="11.5">Local GPU · Ollama / ComfyUI · always available</text>
+  <rect x="360" y="126" width="58" height="20" rx="10" fill="#43d19b" fill-opacity="0.14" stroke="#43d19b" stroke-opacity="0.5"/>
+  <text x="389" y="140" fill="#93e7c6" text-anchor="middle" font-size="10.5" font-weight="700">Online</text>
+
+  <!-- Colab row -->
+  <rect x="50" y="210" width="386" height="102" rx="12" fill="#15181f" stroke="#2a2e38"/>
+  <text x="66" y="238" class="h" font-size="14">Google Colab · T4</text>
+  <text x="66" y="259" class="m" font-size="11.5">Runtime: Ollama · chat / multimodal</text>
+  <text x="66" y="288" class="m" font-size="11">NVIDIA T4 · 16 GB · 3 models · heartbeat 8s ago</text>
+  <rect x="300" y="222" width="58" height="20" rx="10" fill="#43d19b" fill-opacity="0.14" stroke="#43d19b" stroke-opacity="0.5"/>
+  <text x="329" y="236" fill="#93e7c6" text-anchor="middle" font-size="10.5" font-weight="700">Online</text>
+  <rect x="362" y="222" width="66" height="20" rx="10" fill="#f6c453" fill-opacity="0.12" stroke="#f6c453" stroke-opacity="0.45"/>
+  <text x="395" y="236" fill="#f3d38a" text-anchor="middle" font-size="10.5" font-weight="700">Ephemeral</text>
+
+  <!-- Per-model panel -->
+  <rect x="482" y="56" width="430" height="276" rx="14" fill="#15171d" stroke="#2a2e38"/>
+  <text x="504" y="90" class="h" font-size="16">Settings ›  Models</text>
+
+  <text x="504" y="128" class="m" font-size="12">Chat model</text>
+  <rect x="504" y="138" width="386" height="34" rx="9" fill="#0a0b0f" stroke="#2f3441"/>
+  <text x="520" y="160" class="l" font-size="13">deepseek-r1:latest</text>
+  <text x="874" y="160" class="m" font-size="12" text-anchor="end">▾</text>
+
+  <text x="504" y="200" class="m" font-size="12">Runs on</text>
+  <rect x="504" y="210" width="240" height="34" rx="9" fill="#0a0b0f" stroke="#4dd6e8" stroke-opacity="0.5"/>
+  <text x="520" y="232" class="l" font-size="13">Colab T4</text>
+  <text x="728" y="232" class="m" font-size="12" text-anchor="end">▾</text>
+
+  <text x="760" y="200" class="m" font-size="12">Fallback</text>
+  <rect x="760" y="210" width="130" height="34" rx="9" fill="#0a0b0f" stroke="#2f3441"/>
+  <text x="776" y="232" class="l" font-size="13">This PC</text>
+  <text x="874" y="232" class="m" font-size="12" text-anchor="end">▾</text>
+
+  <circle cx="512" cy="286" r="5" fill="#43d19b"/>
+  <text x="526" y="291" fill="#93e7c6" font-size="12.5">Status: Colab T4 online</text>
+</svg>

--- a/backend/app/compute/__init__.py
+++ b/backend/app/compute/__init__.py
@@ -27,10 +27,21 @@ __all__ = [
     "GeneratedMedia",
     "LocalComputeProvider",
     "OllaBridgeCloudComputeProvider",
+    "ComputeRouter",
+    "route_chat",
     "get_compute_provider",
     "resolve_mode",
     "compute_status",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    # Lazily expose the router without importing it at package import time
+    # (keeps the import graph light for callers that only need status helpers).
+    if name in ("ComputeRouter", "route_chat"):
+        from .router import ComputeRouter, route_chat
+        return {"ComputeRouter": ComputeRouter, "route_chat": route_chat}[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def _build_cloud() -> Optional[OllaBridgeCloudComputeProvider]:
@@ -73,26 +84,33 @@ def _burst_allowed() -> bool:
     return (not COMPUTE_BURST_REQUIRES_PREMIUM) or PREMIUM_COMPUTE_ENABLED
 
 
-async def resolve_mode() -> str:
-    """Resolve the effective mode (never returns ``auto``)."""
+async def resolve_mode(modality: str | None = None) -> str:
+    """Resolve the effective mode (never returns ``auto``).
+
+    ``modality`` makes ``auto`` decide against the runtime the request actually
+    needs (Ollama for chat, ComfyUI for image/video) rather than a single global
+    "is the local GPU up" signal.
+    """
     configured = _configured_mode()
     if configured in ("local", "ollabridge_cloud"):
         return configured
 
-    # auto: prefer the local GPU, then — if bursting is allowed — a *configured*
-    # linked OllaBridge device.
-    if await LocalComputeProvider().available():
+    # auto: prefer the local runtime for this modality, then — if bursting is
+    # allowed — a *configured* linked OllaBridge device.
+    if await LocalComputeProvider().available(modality):
         return "local"
     if _burst_allowed():
         cloud = _build_cloud()
-        if cloud is not None and _cloud_configured() and await cloud.available():
+        if cloud is not None and _cloud_configured() and await cloud.available(modality):
             return "ollabridge_cloud"
     return "local"  # offline (or burst-gated) — compute_status() explains
 
 
-async def get_compute_provider(mode: str | None = None) -> ComputeProvider:
-    """Return the provider for the given (or resolved) mode."""
-    mode = mode or await resolve_mode()
+async def get_compute_provider(
+    mode: str | None = None, modality: str | None = None
+) -> ComputeProvider:
+    """Return the provider for the given (or resolved) mode and modality."""
+    mode = mode or await resolve_mode(modality)
     if mode == "ollabridge_cloud":
         cloud = _build_cloud()
         if cloud is not None:

--- a/backend/app/compute/base.py
+++ b/backend/app/compute/base.py
@@ -18,8 +18,32 @@ opts into cloud or auto mode.
 from __future__ import annotations
 
 import abc
+import json
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, AsyncIterator
+
+
+async def iter_openai_sse(resp: Any) -> AsyncIterator[str]:
+    """Parse an OpenAI-style ``/v1/chat/completions`` SSE stream, yielding the
+    ``choices[0].delta.content`` text deltas. Tolerates keep-alive blanks and
+    the terminal ``data: [DONE]``. ``resp`` is a streaming httpx response."""
+    async for line in resp.aiter_lines():
+        line = line.strip()
+        if not line or not line.startswith("data:"):
+            continue
+        data = line[len("data:"):].strip()
+        if data == "[DONE]":
+            break
+        try:
+            obj = json.loads(data)
+        except Exception:
+            continue
+        choices = obj.get("choices") or []
+        if not choices:
+            continue
+        delta = (choices[0].get("delta") or {}).get("content")
+        if delta:
+            yield delta
 
 
 @dataclass
@@ -51,8 +75,14 @@ class ComputeProvider(abc.ABC):
         ...
 
     @abc.abstractmethod
-    async def available(self) -> bool:
-        """Can this provider serve a request right now?"""
+    async def available(self, modality: str | None = None) -> bool:
+        """Can this provider serve a request right now?
+
+        ``modality`` (``"chat"``/``"multimodal"``/``"image"``/``"video"``/
+        ``"edit"``) lets a provider answer for the specific runtime a request
+        needs — e.g. a healthy Ollama should report *available for chat* even
+        when the ComfyUI image runtime is down. ``None`` means "any runtime".
+        """
         ...
 
     # The following have sensible defaults so a provider only overrides what it
@@ -75,6 +105,16 @@ class ComputeProvider(abc.ABC):
 
     async def chat(self, *, model: str, messages: list[dict], **extra: Any) -> dict:
         raise NotImplementedError(f"{self.name} does not support chat")
+
+    async def chat_stream(
+        self, *, model: str, messages: list[dict], **extra: Any
+    ) -> AsyncIterator[str]:
+        """Yield assistant text deltas. Default: adapt the non-streaming ``chat``
+        into a single chunk, so every provider streams *something* uniformly."""
+        result = await self.chat(model=model, messages=messages, **extra)
+        text = ((result.get("choices") or [{}])[0].get("message", {}) or {}).get("content", "")
+        if text:
+            yield text
 
     def describe(self) -> dict[str, Any]:
         return {"provider": self.name}

--- a/backend/app/compute/cost.py
+++ b/backend/app/compute/cost.py
@@ -1,0 +1,133 @@
+"""
+Cost estimates for routing targets (PR 5).
+
+Provider prices are **not hardcoded** (the design is explicit). Instead this
+module reads a timestamped, user/operator-supplied catalog from persisted
+settings (``ComputeSettings.cost_catalog``) — which can be synced from
+OllaBridge's provider registry rather than duplicated here — and layers sensible
+defaults on top:
+
+  * ``local`` and your own private nodes (``device:``/``source:``/the Cloud
+    relay) are **free** — no incremental GPU fee.
+  * hosted-provider *free* aliases (``provider:free-*``) are free.
+  * any other hosted target is **unknown** until the catalog gives a price
+    (unknown never silently blocks a route; it's surfaced in explanations).
+
+A catalog entry (keyed by exact target or by scheme, e.g. ``"provider:groq"`` or
+``"source:"``) looks like::
+
+    {"usd": 0.02, "per_unit": "request", "currency": "USD",
+     "as_of": "2026-08-01", "note": "list price"}
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from .schemas import ComputeSettings
+
+
+@dataclass
+class CostEstimate:
+    target: str
+    currency: str = "USD"
+    estimated_usd: Optional[float] = None   # None == unknown
+    per_unit: str = "request"
+    as_of: Optional[str] = None
+    note: Optional[str] = None
+
+    @property
+    def known(self) -> bool:
+        return self.estimated_usd is not None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "target": self.target,
+            "currency": self.currency,
+            "estimated_usd": self.estimated_usd,
+            "per_unit": self.per_unit,
+            "as_of": self.as_of,
+            "note": self.note,
+        }
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).date().isoformat()
+
+
+def _scheme(target: str) -> str:
+    """The catalog bucket a target falls in when there's no exact match."""
+    if target == "local":
+        return "local"
+    if target in ("ollabridge_cloud", "ollabridge:any"):
+        return "ollabridge_cloud"
+    for pref in ("device:", "source:", "provider:"):
+        if target.startswith(pref):
+            return pref
+    return target
+
+
+def _catalog_lookup(catalog: dict, target: str) -> Optional[dict]:
+    if target in catalog:
+        return catalog[target]
+    scheme = _scheme(target)
+    if scheme in catalog:
+        return catalog[scheme]
+    return None
+
+
+def estimate_target(
+    target: str, modality: str, settings: Optional[ComputeSettings] = None
+) -> CostEstimate:
+    """Best available cost estimate for running ``modality`` on ``target``."""
+    from . import registry
+    settings = settings or registry.load_settings()
+    catalog = settings.cost_catalog or {}
+
+    entry = _catalog_lookup(catalog, target)
+    if entry is not None:
+        return CostEstimate(
+            target=target,
+            currency=entry.get("currency", "USD"),
+            estimated_usd=entry.get("usd"),
+            per_unit=entry.get("per_unit", "request"),
+            as_of=entry.get("as_of") or _now_iso(),
+            note=entry.get("note"),
+        )
+
+    # Defaults when the catalog is silent.
+    scheme = _scheme(target)
+    if scheme in ("local", "ollabridge_cloud", "device:", "source:"):
+        return CostEstimate(
+            target=target, estimated_usd=0.0, as_of=_now_iso(),
+            note="Your own hardware — no incremental fee",
+        )
+    if scheme == "provider:" and target.startswith("provider:free"):
+        return CostEstimate(
+            target=target, estimated_usd=0.0, as_of=_now_iso(),
+            note="Free hosted tier",
+        )
+    return CostEstimate(
+        target=target, estimated_usd=None, as_of=_now_iso(),
+        note="Pricing not configured",
+    )
+
+
+def effective_budget_usd(
+    route_max: Optional[float], settings: ComputeSettings
+) -> Optional[float]:
+    """The per-request budget in force: the route's own cap wins, else the
+    global setting. ``None`` means no budget."""
+    if route_max is not None:
+        return route_max
+    return settings.max_cost_usd_per_request
+
+
+def within_budget(estimate: CostEstimate, budget_usd: Optional[float]) -> bool:
+    """A target is allowed unless we *know* it exceeds the budget. An unknown
+    cost is never auto-blocked — it's surfaced for the user to decide."""
+    if budget_usd is None or not estimate.known:
+        return True
+    return (estimate.estimated_usd or 0.0) <= budget_usd

--- a/backend/app/compute/health.py
+++ b/backend/app/compute/health.py
@@ -1,0 +1,114 @@
+"""
+Cached health + circuit breaker (PR 2).
+
+The router must not ping every remote endpoint before every request (the design
+doc is explicit about this). Instead it asks this module, which:
+
+* caches a health result per key for ``ttl_s`` seconds, and
+* trips a circuit breaker after ``fail_threshold`` consecutive failures, marking
+  the key unhealthy for ``cooldown_s`` without probing at all.
+
+It is deliberately provider-agnostic: callers pass a ``key`` (e.g.
+``"device:colab"`` or ``"source:openai-x"``) and an async ``probe`` returning a
+bool. A shared module-level cache is used by default so results are reused
+across requests; tests construct their own ``HealthCache`` with an injected
+clock for determinism.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Awaitable, Callable, Optional
+
+Probe = Callable[[], Awaitable[bool]]
+
+
+@dataclass
+class _Entry:
+    healthy: bool = False
+    checked_at: float = 0.0
+    consecutive_failures: int = 0
+    circuit_open_until: float = 0.0
+    has_result: bool = False
+
+
+@dataclass
+class HealthCache:
+    ttl_s: float = 15.0
+    fail_threshold: int = 3
+    cooldown_s: float = 60.0
+    clock: Callable[[], float] = time.monotonic
+    _entries: dict[str, _Entry] = field(default_factory=dict)
+
+    def _entry(self, key: str) -> _Entry:
+        e = self._entries.get(key)
+        if e is None:
+            e = _Entry()
+            self._entries[key] = e
+        return e
+
+    def record(self, key: str, healthy: bool) -> None:
+        """Feed an out-of-band health observation (e.g. a heartbeat) in."""
+        now = self.clock()
+        e = self._entry(key)
+        e.healthy = healthy
+        e.checked_at = now
+        e.has_result = True
+        if healthy:
+            e.consecutive_failures = 0
+            e.circuit_open_until = 0.0
+        else:
+            e.consecutive_failures += 1
+            if e.consecutive_failures >= self.fail_threshold:
+                e.circuit_open_until = now + self.cooldown_s
+
+    def allows(self, key: str) -> bool:
+        """Cheap, probe-free gate the router uses before *attempting* a target:
+        the real call doubles as the health probe, so we only skip a target when
+        the breaker is open or a recent attempt already failed (within ``ttl_s``).
+        Unknown keys are allowed (optimistic — try it once)."""
+        now = self.clock()
+        e = self._entries.get(key)
+        if e is None:
+            return True
+        if e.circuit_open_until and now < e.circuit_open_until:
+            return False
+        if e.has_result and not e.healthy and (now - e.checked_at) < self.ttl_s:
+            return False
+        return True
+
+    async def healthy(self, key: str, probe: Probe) -> bool:
+        """Return cached health, or probe if stale. While the circuit is open the
+        probe is skipped entirely and the key is reported unhealthy."""
+        now = self.clock()
+        e = self._entry(key)
+
+        # Circuit open: fail fast, don't touch the network.
+        if e.circuit_open_until and now < e.circuit_open_until:
+            return False
+
+        # Fresh cache hit.
+        if e.has_result and (now - e.checked_at) < self.ttl_s:
+            return e.healthy
+
+        try:
+            result = bool(await probe())
+        except Exception:
+            result = False
+        self.record(key, result)
+        return result
+
+    def invalidate(self, key: Optional[str] = None) -> None:
+        if key is None:
+            self._entries.clear()
+        else:
+            self._entries.pop(key, None)
+
+
+# Shared cache used by the router in production.
+_shared = HealthCache()
+
+
+def shared_cache() -> HealthCache:
+    return _shared

--- a/backend/app/compute/local.py
+++ b/backend/app/compute/local.py
@@ -27,6 +27,35 @@ _IMAGE_WORKFLOWS = {
     "pony-xl": "txt2img-pony-xl",
 }
 
+# Which local runtime a given modality needs. Chat/multimodal run on Ollama
+# (the LLM), image/video/edit run on ComfyUI. This is why local health has to be
+# per-modality: a healthy Ollama must not be reported "unavailable" just because
+# ComfyUI happens to be down (and vice versa).
+_COMFY_MODALITIES = {"image", "video", "edit"}
+_OLLAMA_MODALITIES = {"chat", "multimodal"}
+
+
+async def _ollama_healthy() -> bool:
+    """Async probe of the local Ollama runtime (``GET /api/tags``)."""
+    try:
+        import httpx
+
+        from app.config import OLLAMA_BASE_URL
+        async with httpx.AsyncClient(timeout=3.0) as client:
+            r = await client.get(f"{OLLAMA_BASE_URL.rstrip('/')}/api/tags")
+            return r.status_code == 200
+    except Exception:
+        return False
+
+
+def _comfy_healthy() -> bool:
+    try:
+        from app.config import COMFY_BASE_URL
+        from app.services.comfyui.client import comfyui_healthy
+        return bool(comfyui_healthy(COMFY_BASE_URL))
+    except Exception:
+        return False
+
 
 class LocalComputeProvider(ComputeProvider):
     name = "local"
@@ -78,21 +107,31 @@ class LocalComputeProvider(ComputeProvider):
     async def chat(self, *, model, messages, **extra) -> dict:
         from app import llm
         kwargs: dict[str, Any] = {"model": model}
-        if "provider" in extra:
-            kwargs["provider"] = extra["provider"]
-        if "temperature" in extra:
-            kwargs["temperature"] = extra["temperature"]
-        if "max_tokens" in extra:
-            kwargs["max_tokens"] = extra["max_tokens"]
+        for key in ("provider", "temperature", "max_tokens", "base_url"):
+            if extra.get(key) is not None:
+                kwargs[key] = extra[key]
         return await llm.chat(messages, **kwargs)
 
-    async def available(self) -> bool:
-        try:
-            from app.config import COMFY_BASE_URL
-            from app.services.comfyui.client import comfyui_healthy
-            return bool(comfyui_healthy(COMFY_BASE_URL))
-        except Exception:
-            return False
+    async def chat_stream(self, *, model, messages, **extra):
+        from app import llm
+        kwargs: dict[str, Any] = {"model": model}
+        for key in ("provider", "temperature", "max_tokens", "base_url"):
+            if extra.get(key) is not None:
+                kwargs[key] = extra[key]
+        async for delta in llm.stream_chat(messages, **kwargs):
+            yield delta
+
+    async def available(self, modality: str | None = None) -> bool:
+        # Per-modality health: chat asks Ollama, image/video/edit ask ComfyUI.
+        # ``None`` means "any local runtime is up".
+        if modality in _OLLAMA_MODALITIES:
+            return await _ollama_healthy()
+        if modality in _COMFY_MODALITIES:
+            return _comfy_healthy()
+        # Unknown / unspecified modality: available if either runtime is up.
+        # Check ComfyUI first (cheap, synchronous) so a healthy image runtime
+        # short-circuits before we touch the network for Ollama.
+        return _comfy_healthy() or await _ollama_healthy()
 
     def describe(self) -> dict[str, Any]:
         from app.config import COMFY_BASE_URL

--- a/backend/app/compute/netguard.py
+++ b/backend/app/compute/netguard.py
@@ -1,0 +1,110 @@
+"""
+SSRF guard for custom compute endpoints (security hardening).
+
+A ``ComputeSource`` can point HomePilot at an arbitrary ``base_url`` (an
+OpenAI-compatible endpoint, a remote ComfyUI). Before the server makes an
+outbound request there — at save time and again before each probe/call — we
+validate the URL so a user (or a compromised setting) can't turn the backend
+into an SSRF proxy.
+
+Policy, tuned for *this* product:
+  * scheme MUST be http/https (no file://, gopher://, …);
+  * the **cloud metadata service** (169.254.169.254, fd00:ec2::254) and other
+    link-local / loopback-as-metadata addresses are always blocked;
+  * private LAN ranges (RFC1918, ULA) are **allowed by default** — self-hosted
+    GPU nodes legitimately live at 10.x / 192.168.x / a ``.local`` host. Operators
+    who want a stricter posture set ``HOMEPILOT_COMPUTE_BLOCK_PRIVATE=true``.
+
+Hostnames are resolved and *every* resolved address is checked, so a name that
+maps to a blocked IP is rejected too. Resolution failures don't hard-block
+(the real request will simply fail) — we only block on a positive match.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+import socket
+from urllib.parse import urlparse
+
+
+class UnsafeEndpointError(ValueError):
+    """Raised when a compute endpoint URL is not allowed to be contacted."""
+
+
+# Link-local (169.254/16, fe80::/10) covers the 169.254.169.254 metadata IP.
+_METADATA_HOSTS = {"169.254.169.254", "fd00:ec2::254", "metadata.google.internal"}
+
+
+def _block_private() -> bool:
+    return os.getenv("HOMEPILOT_COMPUTE_BLOCK_PRIVATE", "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def _ip_is_blocked(ip: ipaddress._BaseAddress) -> bool:
+    # Always block link-local (covers the 169.254.169.254 metadata IP),
+    # multicast, and the unspecified address — regardless of policy.
+    if ip.is_link_local or ip.is_multicast or ip.is_unspecified:
+        return True
+    # Loopback (a local Ollama/ComfyUI on 127.0.0.1 / ::1) and private LAN
+    # (a self-hosted vLLM on 10.x / 192.168.x) are legitimate targets by
+    # default; only blocked when the operator opts into the strict policy.
+    # NB: is_link_local is checked first, so metadata (which is also is_private
+    # per RFC) is already blocked above and never reaches this allowance.
+    if ip.is_loopback or ip.is_private:
+        return _block_private()
+    return False
+
+
+def _resolve(host: str) -> list[ipaddress._BaseAddress]:
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except Exception:
+        return []
+    out: list[ipaddress._BaseAddress] = []
+    for info in infos:
+        addr = info[4][0]
+        try:
+            out.append(ipaddress.ip_address(addr.split("%")[0]))
+        except ValueError:
+            continue
+    return out
+
+
+def validate_outbound_url(url: str | None) -> None:
+    """Raise ``UnsafeEndpointError`` if ``url`` must not be contacted. No-op for
+    an empty URL (nothing to dial)."""
+    if not url:
+        return
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise UnsafeEndpointError(f"Only http/https endpoints are allowed (got {parsed.scheme or 'no'} scheme).")
+    host = (parsed.hostname or "").strip()
+    if not host:
+        raise UnsafeEndpointError("Endpoint URL has no host.")
+    if host.lower() in _METADATA_HOSTS:
+        raise UnsafeEndpointError("Cloud metadata endpoints are not allowed.")
+
+    # Literal IP → check directly; hostname → check every resolved address.
+    try:
+        literal = ipaddress.ip_address(host)
+    except ValueError:
+        literal = None
+    candidates = [literal] if literal is not None else _resolve(host)
+    for ip in candidates:
+        if ip is None:
+            continue
+        # The metadata IP is link-local; always blocked regardless of policy.
+        if str(ip) in _METADATA_HOSTS or ip.is_link_local:
+            raise UnsafeEndpointError("Endpoint resolves to a blocked link-local/metadata address.")
+        if _ip_is_blocked(ip):
+            raise UnsafeEndpointError(f"Endpoint resolves to a blocked address ({ip}).")
+
+
+def is_safe_outbound_url(url: str | None) -> bool:
+    try:
+        validate_outbound_url(url)
+        return True
+    except UnsafeEndpointError:
+        return False

--- a/backend/app/compute/ollabridge_cloud.py
+++ b/backend/app/compute/ollabridge_cloud.py
@@ -20,7 +20,7 @@ from typing import Any
 
 import httpx
 
-from .base import ComputeProvider, GeneratedMedia
+from .base import ComputeProvider, GeneratedMedia, iter_openai_sse
 
 
 class OllaBridgeCloudComputeProvider(ComputeProvider):
@@ -140,7 +140,20 @@ class OllaBridgeCloudComputeProvider(ComputeProvider):
             r.raise_for_status()
             return r.json()
 
-    async def available(self) -> bool:
+    async def chat_stream(self, *, model, messages, **extra):
+        body = {"model": model, "messages": messages, "stream": True}
+        body.update({k: v for k, v in extra.items() if v is not None})
+        async with self._client(self.timeout) as client:
+            async with client.stream(
+                "POST", "/v1/chat/completions", json=body, headers=self._headers()
+            ) as resp:
+                resp.raise_for_status()
+                async for delta in iter_openai_sse(resp):
+                    yield delta
+
+    async def available(self, modality: str | None = None) -> bool:
+        # The Cloud relay is a single endpoint regardless of modality; per-device
+        # / per-model capability is enforced Cloud-side at routing time.
         if not self.base_url:
             return False
         try:

--- a/backend/app/compute/policies.py
+++ b/backend/app/compute/policies.py
@@ -1,0 +1,213 @@
+"""
+Routing policies (PR 2).
+
+Turns a ``(modality, model_id)`` request into an *ordered list of targets* to
+try. Resolution order matches the design doc:
+
+    1. Explicit per-model route (registry).
+    2. Modality default (persisted settings).
+    3. Global compute default (settings.compute_mode — the ex-env flag).
+    4. Safe fallback policy (a local tail, unless privacy forbids it).
+
+Targets are opaque strings the providers factory knows how to build:
+
+    "local"                     local runtime (Ollama/ComfyUI)
+    "ollabridge_cloud"          the Cloud relay, any owned device
+    "ollabridge:any"            alias of the above
+    "device:<id>"               the Cloud relay pinned to one device
+    "source:<id>"               a configured ComputeSource (e.g. OpenAI-compatible)
+    "provider:<alias>"          a hosted-provider alias (e.g. free-best)
+
+This module is pure and synchronous: it does the *static* filtering (privacy,
+manifest capability, VRAM) and ordering. Dynamic health/heartbeat filtering is
+the router's job, because it owns the cached probes — the doc's "don't ping
+every endpoint per request" rule.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from . import registry
+from .schemas import ComputeSettings, ModelRoute
+
+# modality → the capability a device manifest must advertise to serve it.
+_MODALITY_CAPABILITY = {
+    "chat": "chat",
+    "multimodal": "multimodal",
+    "image": "image",
+    "video": "video",
+    "edit": "edit",
+}
+
+_HOSTED_PREFIXES = ("provider:",)
+_REMOTE_PREFIXES = ("ollabridge", "device:", "source:", "provider:")
+
+
+def _mode_targets(compute_mode: str, modality: str) -> list[str]:
+    mode = (compute_mode or "local").strip().lower()
+    if mode == "ollabridge_cloud":
+        return ["ollabridge_cloud"]
+    if mode == "auto":
+        # prefer local, then burst to the Cloud relay (PR 1 `auto` semantics).
+        return ["local", "ollabridge_cloud"]
+    return ["local"]
+
+
+def _order_by_strategy(strategy: str, primary: str, fallbacks: list[str]) -> list[str]:
+    ordered = [primary, *fallbacks]
+    if strategy == "prefer_local":
+        ordered.sort(key=lambda t: 0 if t == "local" else 1)
+    elif strategy == "prefer_remote":
+        ordered.sort(key=lambda t: 0 if _is_remote(t) else 1)
+    # "pinned" and "lowest_cost" keep the author's order (no cost model yet).
+    return ordered
+
+
+def _is_remote(target: str) -> bool:
+    return any(target.startswith(p) or target == p.rstrip(":") for p in _REMOTE_PREFIXES)
+
+
+def _is_hosted(target: str) -> bool:
+    return any(target.startswith(p) for p in _HOSTED_PREFIXES)
+
+
+def _dedupe(targets: list[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for t in targets:
+        if t and t not in seen:
+            seen.add(t)
+            out.append(t)
+    return out
+
+
+def _apply_privacy(targets: list[str], privacy: str) -> list[str]:
+    if privacy == "local_only":
+        return [t for t in targets if t == "local"]
+    if privacy == "private_nodes":
+        # own machines and private relays/devices/sources — but no hosted APIs.
+        return [t for t in targets if not _is_hosted(t)]
+    return targets  # hosted_allowed
+
+
+def _capability_ok(model_id: str, target: str, modality: str) -> bool:
+    """Static capability/VRAM filter for device-pinned targets, when we have a
+    manifest to check against. No manifest ⇒ we don't block (optimistic)."""
+    if not target.startswith("device:"):
+        return True
+    manifest = registry.get_manifest(model_id)
+    if manifest is None:
+        return True
+    device_id = target.split(":", 1)[1]
+    if manifest.device_ids and device_id not in manifest.device_ids:
+        return False
+    need = _MODALITY_CAPABILITY.get(modality)
+    if need and manifest.capabilities and not manifest.supports(need):
+        return False
+    if manifest.minimum_vram_mb:
+        device = registry.get_device(device_id)
+        if device and device.vram_mb is not None and device.vram_mb < manifest.minimum_vram_mb:
+            return False
+    return True
+
+
+def resolve_targets(
+    modality: str,
+    model_id: Optional[str] = None,
+    *,
+    settings: Optional[ComputeSettings] = None,
+) -> list[str]:
+    """Ordered targets to try for this request (see module docstring)."""
+    settings = settings or registry.load_settings()
+
+    route: Optional[ModelRoute] = (
+        registry.get_route(model_id, modality) if model_id else None
+    )
+    if route is not None:
+        targets = _order_by_strategy(
+            route.normalized_strategy(), route.primary_target, list(route.fallback_targets)
+        )
+        privacy = route.normalized_privacy()
+    else:
+        default = settings.default_for(modality)
+        if default is not None:
+            primary = default.target or _mode_targets(settings.compute_mode, modality)[0]
+            targets = _order_by_strategy(
+                default.strategy, primary, list(default.fallback_targets)
+            )
+            privacy = default.privacy
+        else:
+            targets = _mode_targets(settings.compute_mode, modality)
+            privacy = "private_nodes"
+
+    # Static filters: privacy, then per-model capability/VRAM.
+    targets = _apply_privacy(targets, privacy)
+    if model_id:
+        targets = [t for t in targets if _capability_ok(model_id, t, modality)]
+
+    # Budget filter (PR 5): drop targets we *know* exceed the per-request budget.
+    # Unknown-cost targets are kept (surfaced in explain, not silently dropped).
+    from . import cost
+    budget = cost.effective_budget_usd(route.max_cost_usd if route else None, settings)
+    if budget is not None:
+        targets = [
+            t for t in targets
+            if cost.within_budget(cost.estimate_target(t, modality, settings), budget)
+        ]
+
+    targets = _dedupe(targets)
+
+    # Safe fallback tail: a local runtime is always the last resort unless the
+    # privacy policy explicitly forbids leaving... it never does for local.
+    if privacy != "local_only" and "local" not in targets:
+        targets.append("local")
+    if not targets:
+        targets = ["local"]
+    return targets
+
+
+def explain(modality: str, model_id: Optional[str] = None) -> dict:
+    """Diagnostics for the admin UI / request tracing — now cost-aware.
+
+    Reports the chosen order, the per-request budget in force, and, for every
+    *candidate* target (before the budget filter), its cost estimate and whether
+    the budget excluded it — so the UI can say why a hosted option was skipped.
+    """
+    from . import cost
+    route = registry.get_route(model_id, modality) if model_id else None
+    settings = registry.load_settings()
+    budget = cost.effective_budget_usd(route.max_cost_usd if route else None, settings)
+
+    chosen = resolve_targets(modality, model_id, settings=settings)
+
+    # Candidate set = chosen targets ∪ anything the budget removed, so the
+    # explanation can show excluded hosted options with their price.
+    candidates = list(chosen)
+    if route is not None:
+        for t in [route.primary_target, *route.fallback_targets]:
+            if t not in candidates:
+                candidates.append(t)
+
+    costs = []
+    for t in candidates:
+        est = cost.estimate_target(t, modality, settings)
+        over = budget is not None and est.known and not cost.within_budget(est, budget)
+        row = est.to_dict()
+        row["over_budget"] = over
+        row["selected"] = t in chosen
+        costs.append(row)
+
+    return {
+        "modality": modality,
+        "model_id": model_id,
+        "matched": (
+            "route" if route is not None
+            else "modality_default" if settings.default_for(modality) is not None
+            else "global_default"
+        ),
+        "compute_mode": settings.compute_mode,
+        "budget_usd": budget,
+        "targets": chosen,
+        "costs": costs,
+    }

--- a/backend/app/compute/providers/__init__.py
+++ b/backend/app/compute/providers/__init__.py
@@ -1,0 +1,115 @@
+"""
+Provider factory (PR 2).
+
+Turns a routing *target* string (see ``policies``) into a concrete
+``ComputeProvider`` plus any per-call routing metadata. The existing PR 1
+providers (``LocalComputeProvider``, ``OllaBridgeCloudComputeProvider``) live at
+the package root and are re-exported here; new backends (OpenAI-compatible) live
+in this subpackage.
+
+``build_target`` returns ``None`` for a target that can't be built right now (a
+missing/disabled source, an unconfigured cloud, an unimplemented alias); the
+router simply skips it and moves to the next candidate.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from ..base import ComputeProvider
+from ..local import LocalComputeProvider
+from ..ollabridge_cloud import OllaBridgeCloudComputeProvider
+from .openai_compatible import OpenAICompatibleComputeProvider
+
+__all__ = [
+    "LocalComputeProvider",
+    "OllaBridgeCloudComputeProvider",
+    "OpenAICompatibleComputeProvider",
+    "BuiltTarget",
+    "build_target",
+]
+
+
+@dataclass
+class BuiltTarget:
+    target: str
+    provider: ComputeProvider
+    health_key: str
+    remote: bool = False
+    extra: dict[str, Any] = field(default_factory=dict)  # merged into call kwargs
+
+
+def _build_cloud(settings) -> Optional[OllaBridgeCloudComputeProvider]:
+    """Cloud relay provider from persisted settings + env token (PR 1 parity)."""
+    from app.config import OLLABRIDGE_CLOUD_TIMEOUT, OLLABRIDGE_CLOUD_TOKEN
+    cloud_url = settings.cloud_url
+    if not cloud_url:
+        return None
+    return OllaBridgeCloudComputeProvider(
+        cloud_url,
+        OLLABRIDGE_CLOUD_TOKEN,
+        image_model=settings.cloud_image_model,
+        video_model=settings.cloud_video_model,
+        timeout=OLLABRIDGE_CLOUD_TIMEOUT,
+    )
+
+
+def build_target(target: str, *, settings=None) -> Optional[BuiltTarget]:
+    from .. import registry
+    from .. import secrets
+
+    settings = settings or registry.load_settings()
+
+    if target == "local":
+        return BuiltTarget("local", LocalComputeProvider(), "local", remote=False)
+
+    if target in ("ollabridge_cloud", "ollabridge:any"):
+        cloud = _build_cloud(settings)
+        if cloud is None:
+            return None
+        return BuiltTarget(target, cloud, "ollabridge_cloud", remote=True)
+
+    if target.startswith("device:"):
+        device_id = target.split(":", 1)[1]
+        cloud = _build_cloud(settings)
+        if cloud is None:
+            return None
+        return BuiltTarget(
+            target,
+            cloud,
+            f"device:{device_id}",
+            remote=True,
+            extra={"routing": {"device_id": device_id}},
+        )
+
+    if target.startswith("source:"):
+        source_id = target.split(":", 1)[1]
+        source = registry.get_source(source_id)
+        if source is None or not source.enabled:
+            return None
+        key = f"source:{source_id}"
+        if source.kind == "local":
+            return BuiltTarget(target, LocalComputeProvider(), key, remote=False)
+        if source.kind in ("openai_compatible", "vllm", "openai_api"):
+            # SSRF defense-in-depth: never dial a blocked endpoint even if a bad
+            # base_url slipped into the registry.
+            from ..netguard import is_safe_outbound_url
+            if not is_safe_outbound_url(source.base_url):
+                return None
+            api_key = secrets.get_secret(source.credential_ref)
+            provider = OpenAICompatibleComputeProvider(
+                source.base_url or "",
+                api_key,
+                default_model=(source.meta or {}).get("default_model"),
+            )
+            return BuiltTarget(target, provider, key, remote=True)
+        if source.kind in ("ollabridge", "ollabridge_cloud"):
+            cloud = _build_cloud(settings)
+            if cloud is None:
+                return None
+            return BuiltTarget(target, cloud, key, remote=True)
+        return None
+
+    # "provider:<alias>" (hosted-provider aliases) not yet implemented here.
+    return None

--- a/backend/app/compute/providers/openai_compatible.py
+++ b/backend/app/compute/providers/openai_compatible.py
@@ -1,0 +1,99 @@
+"""
+OpenAI-compatible compute provider (PR 2).
+
+A ``direct`` source: HomePilot talks straight to any endpoint that speaks the
+OpenAI ``/v1/chat/completions`` shape (a self-hosted vLLM, a hosted router, a
+generic gateway). The base URL comes from the ``ComputeSource``; the API key
+comes from the server-side secrets store via the source's ``credential_ref`` —
+never from the client.
+
+Transport is injectable so it is unit-testable without a live endpoint.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import httpx
+
+from ..base import ComputeProvider, iter_openai_sse
+
+
+class OpenAICompatibleComputeProvider(ComputeProvider):
+    name = "openai_compatible"
+
+    def __init__(
+        self,
+        base_url: str,
+        api_key: Optional[str] = None,
+        *,
+        default_model: Optional[str] = None,
+        timeout: float = 120.0,
+        transport: httpx.BaseTransport | None = None,
+    ):
+        self.base_url = (base_url or "").rstrip("/")
+        self.api_key = api_key
+        self.default_model = default_model
+        self.timeout = timeout
+        self._transport = transport
+
+    def _headers(self) -> dict[str, str]:
+        h = {"Content-Type": "application/json"}
+        if self.api_key:
+            h["Authorization"] = f"Bearer {self.api_key}"
+        return h
+
+    def _client(self, timeout: float) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            base_url=self.base_url, timeout=timeout, transport=self._transport
+        )
+
+    async def generate_image(self, *, prompt, model=None, **extra) -> Any:
+        raise NotImplementedError(f"{self.name} does not support image generation")
+
+    async def chat(self, *, model, messages, **extra) -> dict:
+        body: dict[str, Any] = {"model": model or self.default_model or "", "messages": messages}
+        for key in ("temperature", "max_tokens"):
+            if extra.get(key) is not None:
+                body[key] = extra[key]
+        async with self._client(self.timeout) as client:
+            r = await client.post(
+                "/v1/chat/completions", json=body, headers=self._headers()
+            )
+            r.raise_for_status()
+            return r.json()
+
+    async def chat_stream(self, *, model, messages, **extra):
+        body: dict[str, Any] = {"model": model or self.default_model or "", "messages": messages, "stream": True}
+        for key in ("temperature", "max_tokens"):
+            if extra.get(key) is not None:
+                body[key] = extra[key]
+        async with self._client(self.timeout) as client:
+            async with client.stream(
+                "POST", "/v1/chat/completions", json=body, headers=self._headers()
+            ) as resp:
+                resp.raise_for_status()
+                async for delta in iter_openai_sse(resp):
+                    yield delta
+
+    async def available(self, modality: str | None = None) -> bool:
+        if not self.base_url:
+            return False
+        # Only chat is supported; anything else is "unavailable" here.
+        if modality not in (None, "chat", "multimodal"):
+            return False
+        try:
+            async with self._client(5.0) as client:
+                # /v1/models is the conventional liveness probe; tolerate 401
+                # (endpoint is up, key may be scoped) as "reachable".
+                r = await client.get("/v1/models", headers=self._headers())
+                return r.status_code < 500
+        except Exception:
+            return False
+
+    def describe(self) -> dict[str, Any]:
+        return {
+            "provider": "openai_compatible",
+            "base_url": self.base_url,
+            "configured": bool(self.api_key),
+        }

--- a/backend/app/compute/readiness.py
+++ b/backend/app/compute/readiness.py
@@ -1,0 +1,97 @@
+"""
+Production-readiness check for Compute Sources & Routing.
+
+Ships a single, honest signal an operator can hit before exposing HomePilot to
+the world: are the things that must be configured for a safe multi-user, remote-
+compute deployment actually configured? It never fails a request — it reports.
+
+What it checks (compute-scoped; HomePilot user auth + the Cloud control plane
+have their own checks):
+  * SSRF guard — always on (see ``netguard``).
+  * Credential encryption at rest — compute source secrets and the per-user
+    cloud token are only encrypted when their Fernet keys are set.
+  * External API key — the OpenAI-compatible ingress requires one off-localhost.
+  * Canonical Cloud URL — one production URL, not a stale HF Space.
+  * Private-endpoint policy — informational (private LAN is allowed by design).
+
+``production_ready`` is False when any *blocking* item is unmet; ``warnings``
+explains each in plain language so the fix is obvious.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+_CANONICAL_CLOUD_URL = "https://app.ollabridge.com"
+
+
+def _has(key: str) -> bool:
+    return bool((os.getenv(key) or "").strip())
+
+
+def _crypto_available() -> bool:
+    try:
+        import cryptography  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+def production_readiness() -> dict[str, Any]:
+    from app import config
+
+    crypto = _crypto_available()
+    source_secrets_encrypted = crypto and _has("HOMEPILOT_COMPUTE_SECRET_KEY")
+    cloud_token_encrypted = crypto and _has("HOMEPILOT_CLOUD_TOKEN_KEY")
+    api_key_set = bool((getattr(config, "API_KEY", "") or "").strip())
+    cloud_url = (getattr(config, "OLLABRIDGE_CLOUD_URL", "") or "").strip()
+    block_private = (os.getenv("HOMEPILOT_COMPUTE_BLOCK_PRIVATE", "").strip().lower()
+                     in ("1", "true", "yes", "on"))
+
+    checks = {
+        "ssrf_guard": True,
+        "source_secrets_encrypted": source_secrets_encrypted,
+        "cloud_token_encrypted": cloud_token_encrypted,
+        "external_api_key_set": api_key_set,
+        "cloud_url_configured": bool(cloud_url),
+        "block_private_endpoints": block_private,
+    }
+
+    warnings: list[str] = []
+    # Blocking items — a worldwide multi-user deployment should not ship without these.
+    blocking = True
+    if not source_secrets_encrypted:
+        warnings.append(
+            "Set HOMEPILOT_COMPUTE_SECRET_KEY (a Fernet key) and install "
+            "'cryptography' so compute source credentials are encrypted at rest."
+        )
+        blocking = False
+    if not cloud_token_encrypted:
+        warnings.append(
+            "Set HOMEPILOT_CLOUD_TOKEN_KEY so the per-user OllaBridge cloud token "
+            "is encrypted at rest."
+        )
+        blocking = False
+    if not api_key_set:
+        warnings.append(
+            "Set API_KEY so the OpenAI-compatible ingress requires authentication "
+            "from off-localhost clients."
+        )
+        blocking = False
+
+    # Non-blocking advisories.
+    if cloud_url and cloud_url.rstrip("/") != _CANONICAL_CLOUD_URL:
+        warnings.append(
+            f"OLLABRIDGE_CLOUD_URL is '{cloud_url}'. Prefer the canonical "
+            f"production URL {_CANONICAL_CLOUD_URL} unless self-hosting Cloud."
+        )
+
+    return {
+        "production_ready": blocking,
+        "checks": checks,
+        "warnings": warnings,
+        # The compute registry is single-tenant today: all linked users share one
+        # registry. Surfaced so operators plan multi-tenant deployments accordingly.
+        "multi_tenant_registry": False,
+    }

--- a/backend/app/compute/registry.py
+++ b/backend/app/compute/registry.py
@@ -1,0 +1,302 @@
+"""
+Compute registry (PR 2) — persisted sources, devices, manifests, routes, and
+settings.
+
+SQLite-backed and fully additive (new tables via ``CREATE TABLE IF NOT
+EXISTS``). This is where PR 1's env-only global flags become *persisted user
+settings*: ``load_settings()`` starts from ``ComputeSettings.from_env()`` (the
+deployment defaults) and overlays whatever the user has saved, so an
+unconfigured install behaves exactly as before while the UI can persist
+per-model routing on top.
+
+Everything degrades safely: read failures return empty/defaults rather than
+raising, so a missing/locked DB can never take down an inference path — the
+router just falls back to the legacy global-mode behaviour.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from typing import Optional
+
+from ..storage import _get_db_path
+from .schemas import (
+    ComputeDevice,
+    ComputeSettings,
+    ComputeSource,
+    ModelManifest,
+    ModelRoute,
+)
+
+_SETTINGS_KEY = "settings"
+
+
+def _conn() -> sqlite3.Connection:
+    con = sqlite3.connect(_get_db_path())
+    con.row_factory = sqlite3.Row
+    return con
+
+
+def ensure_tables() -> None:
+    con = _conn()
+    try:
+        con.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS compute_sources (
+                id            TEXT PRIMARY KEY,
+                data          TEXT NOT NULL,
+                updated_at    REAL NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS compute_devices (
+                id            TEXT PRIMARY KEY,
+                source_id     TEXT NOT NULL,
+                data          TEXT NOT NULL,
+                updated_at    REAL NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS compute_manifests (
+                id            TEXT PRIMARY KEY,
+                data          TEXT NOT NULL,
+                updated_at    REAL NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS compute_routes (
+                modality      TEXT NOT NULL,
+                model_id      TEXT NOT NULL,
+                data          TEXT NOT NULL,
+                updated_at    REAL NOT NULL,
+                PRIMARY KEY (modality, model_id)
+            );
+            CREATE TABLE IF NOT EXISTS compute_kv (
+                key           TEXT PRIMARY KEY,
+                data          TEXT NOT NULL,
+                updated_at    REAL NOT NULL
+            );
+            """
+        )
+        con.commit()
+    finally:
+        con.close()
+
+
+def _write(table: str, columns: dict, pk_cols: tuple[str, ...], payload: dict) -> None:
+    """Upsert a row. ``columns`` are the indexed/id columns to store; ``pk_cols``
+    is the conflict target (must match the table's PRIMARY KEY)."""
+    ensure_tables()
+    col_names = list(columns.keys()) + ["data", "updated_at"]
+    cols = ", ".join(col_names)
+    placeholders = ", ".join(["?"] * len(col_names))
+    conflict = ", ".join(pk_cols)
+    values = (*columns.values(), json.dumps(payload), time.time())
+    con = _conn()
+    try:
+        con.execute(
+            f"INSERT INTO {table} ({cols}) VALUES ({placeholders}) "
+            f"ON CONFLICT({conflict}) DO UPDATE SET data=excluded.data, "
+            f"updated_at=excluded.updated_at",
+            values,
+        )
+        con.commit()
+    finally:
+        con.close()
+
+
+def _read_all(table: str) -> list[dict]:
+    try:
+        ensure_tables()
+        con = _conn()
+        try:
+            rows = con.execute(f"SELECT data FROM {table}").fetchall()
+        finally:
+            con.close()
+    except Exception:
+        return []
+    out = []
+    for r in rows:
+        try:
+            out.append(json.loads(r["data"]))
+        except Exception:
+            continue
+    return out
+
+
+# ---- sources ----------------------------------------------------------------
+
+def upsert_source(source: ComputeSource) -> ComputeSource:
+    _write("compute_sources", {"id": source.id}, ("id",), source.to_dict())
+    return source
+
+
+def list_sources() -> list[ComputeSource]:
+    return [ComputeSource.from_dict(d) for d in _read_all("compute_sources")]
+
+
+def get_source(source_id: str) -> Optional[ComputeSource]:
+    for s in list_sources():
+        if s.id == source_id:
+            return s
+    return None
+
+
+def delete_source(source_id: str) -> None:
+    _delete("compute_sources", "id", source_id)
+
+
+# ---- devices ----------------------------------------------------------------
+
+def upsert_device(device: ComputeDevice) -> ComputeDevice:
+    if device.last_heartbeat is None:
+        device.last_heartbeat = time.time()
+    _write("compute_devices", {"id": device.id, "source_id": device.source_id}, ("id",), device.to_dict())
+    return device
+
+
+def list_devices(source_id: Optional[str] = None) -> list[ComputeDevice]:
+    devices = [ComputeDevice.from_dict(d) for d in _read_all("compute_devices")]
+    if source_id is not None:
+        devices = [d for d in devices if d.source_id == source_id]
+    return devices
+
+
+def get_device(device_id: str) -> Optional[ComputeDevice]:
+    for d in list_devices():
+        if d.id == device_id:
+            return d
+    return None
+
+
+def delete_device(device_id: str) -> None:
+    _delete("compute_devices", "id", device_id)
+
+
+# ---- manifests --------------------------------------------------------------
+
+def upsert_manifest(manifest: ModelManifest) -> ModelManifest:
+    _write("compute_manifests", {"id": manifest.id}, ("id",), manifest.to_dict())
+    return manifest
+
+
+def list_manifests() -> list[ModelManifest]:
+    return [ModelManifest.from_dict(d) for d in _read_all("compute_manifests")]
+
+
+def get_manifest(model_id: str) -> Optional[ModelManifest]:
+    for m in list_manifests():
+        if m.id == model_id:
+            return m
+    return None
+
+
+def delete_manifest(model_id: str) -> None:
+    _delete("compute_manifests", "id", model_id)
+
+
+# ---- routes -----------------------------------------------------------------
+
+def upsert_route(route: ModelRoute) -> ModelRoute:
+    _write(
+        "compute_routes",
+        {"modality": route.modality, "model_id": route.model_id},
+        ("modality", "model_id"),
+        route.to_dict(),
+    )
+    return route
+
+
+def list_routes() -> list[ModelRoute]:
+    return [ModelRoute.from_dict(d) for d in _read_all("compute_routes")]
+
+
+def get_route(model_id: str, modality: Optional[str] = None) -> Optional[ModelRoute]:
+    """Exact (modality, model_id) match preferred; otherwise the first route for
+    the model regardless of modality (a name-only binding)."""
+    routes = list_routes()
+    if modality is not None:
+        for r in routes:
+            if r.model_id == model_id and r.modality == modality:
+                return r
+    for r in routes:
+        if r.model_id == model_id:
+            return r
+    return None
+
+
+def delete_route(model_id: str, modality: str) -> None:
+    try:
+        ensure_tables()
+        con = _conn()
+        try:
+            con.execute(
+                "DELETE FROM compute_routes WHERE model_id=? AND modality=?",
+                (model_id, modality),
+            )
+            con.commit()
+        finally:
+            con.close()
+    except Exception:
+        pass
+
+
+# ---- settings ---------------------------------------------------------------
+
+def load_settings() -> ComputeSettings:
+    """Env/deployment defaults overlaid with any persisted overrides."""
+    settings = ComputeSettings.from_env()
+    try:
+        ensure_tables()
+        con = _conn()
+        try:
+            row = con.execute(
+                "SELECT data FROM compute_kv WHERE key=?", (_SETTINGS_KEY,)
+            ).fetchone()
+        finally:
+            con.close()
+    except Exception:
+        return settings
+    if not row:
+        return settings
+    try:
+        stored = json.loads(row["data"])
+    except Exception:
+        return settings
+    # Overlay: persisted values win, but unset keys keep env defaults.
+    merged = settings.to_dict()
+    merged.update({k: v for k, v in stored.items() if v is not None})
+    if stored.get("modality_defaults"):
+        merged["modality_defaults"] = stored["modality_defaults"]
+    return ComputeSettings.from_dict(merged)
+
+
+def save_settings(settings: ComputeSettings) -> ComputeSettings:
+    _write("compute_kv", {"key": _SETTINGS_KEY}, ("key",), settings.to_dict())
+    return settings
+
+
+def _delete(table: str, col: str, value: str) -> None:
+    try:
+        ensure_tables()
+        con = _conn()
+        try:
+            con.execute(f"DELETE FROM {table} WHERE {col}=?", (value,))
+            con.commit()
+        finally:
+            con.close()
+    except Exception:
+        pass
+
+
+def is_empty() -> bool:
+    """True when nothing has been persisted — the router then behaves exactly as
+    PR 1 (pure env-driven global mode)."""
+    try:
+        ensure_tables()
+        con = _conn()
+        try:
+            for table in ("compute_sources", "compute_routes", "compute_kv"):
+                if con.execute(f"SELECT 1 FROM {table} LIMIT 1").fetchone():
+                    return False
+        finally:
+            con.close()
+    except Exception:
+        return True
+    return True

--- a/backend/app/compute/router.py
+++ b/backend/app/compute/router.py
@@ -1,0 +1,380 @@
+"""
+ComputeRouter (PR 1 seam, PR 2 per-model routing).
+
+The single seam every inference path goes through. PR 1 made it a
+behaviour-preserving façade over the global compute mode; PR 2 makes it resolve
+a *per-model* plan from the registry and try candidates in order.
+
+Resolution (see ``policies``):
+    explicit route → modality default → global compute mode → safe local tail.
+
+Dispatch:
+    * Candidates are tried in order. The **real call is the health probe** — we
+      don't ping every endpoint first (the design's rule). A cheap circuit
+      breaker (``health.HealthCache.allows``) skips targets whose last attempt
+      just failed, so a dead remote is retried at most once per TTL.
+    * Fallback is **pre-output only**. These calls are non-streaming (they
+      return a complete result), so a candidate failing means nothing reached
+      the user and advancing to the next candidate is safe.
+    * A local runtime is always the final safety net.
+
+Behaviour preservation: with an empty registry, ``resolve_targets`` returns the
+targets implied by ``settings.compute_mode`` (which defaults to the env flag),
+so an unconfigured install routes exactly as PR 1 did.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable, Optional
+
+from . import health, policies, providers
+from .base import GeneratedMedia
+from .local import LocalComputeProvider
+
+# call(provider, extra) -> awaitable result
+_Call = Callable[[Any, dict], Awaitable[Any]]
+
+
+class ComputeRouter:
+    def __init__(self, cache: Optional[health.HealthCache] = None):
+        self._cache = cache or health.shared_cache()
+
+    async def _dispatch(
+        self,
+        modality: str,
+        model_id: Optional[str],
+        call: _Call,
+        report: Optional[dict] = None,
+    ):
+        targets = policies.resolve_targets(modality, model_id)
+        settings = None
+        last_exc: Optional[Exception] = None
+        tried_local = False
+        failures: list[dict] = []  # attempts that failed before a winner
+
+        def _win(target: str, device_id: Optional[str]) -> None:
+            if report is None:
+                return
+            report["target"] = target
+            report["device_id"] = device_id
+            report["fell_back"] = bool(failures)
+            report["attempts"] = failures + [{"target": target, "ok": True}]
+            if failures:
+                report["reason"] = failures[0].get("reason")
+
+        for target in targets:
+            # Heartbeat-aware: don't dial a device the registry knows is offline —
+            # skip it with an actionable reason instead of a doomed round-trip.
+            offline = _device_offline_reason(target)
+            if offline is not None:
+                failures.append({"target": target, "ok": False, "reason": offline})
+                continue
+            built = providers.build_target(target, settings=settings)
+            if built is None:
+                failures.append({"target": target, "ok": False, "reason": "not available"})
+                continue
+            if not self._cache.allows(built.health_key):
+                failures.append({"target": target, "ok": False, "reason": "recently failed"})
+                continue
+            if built.health_key == "local":
+                tried_local = True
+            try:
+                result = await call(built.provider, built.extra)
+                self._cache.record(built.health_key, True)
+                _win(built.target, (built.extra.get("routing") or {}).get("device_id"))
+                return self._annotate(result, built)
+            except Exception as exc:  # pre-output: safe to advance
+                last_exc = exc
+                self._cache.record(built.health_key, False)
+                failures.append({"target": target, "ok": False, "reason": str(exc)[:140]})
+                continue
+
+        # Final safety net: a local runtime, even if the breaker skipped it above.
+        if not tried_local:
+            local = LocalComputeProvider()
+            try:
+                result = await call(local, {})
+                _win("local", None)
+                return result
+            except Exception as exc:
+                last_exc = exc
+
+        if last_exc is not None:
+            raise last_exc
+        raise RuntimeError("no compute target available for this request")
+
+    @staticmethod
+    def _annotate(result: Any, built: providers.BuiltTarget) -> Any:
+        # Surface which target served the request for diagnostics, without
+        # changing the shape callers already consume.
+        if isinstance(result, GeneratedMedia):
+            result.meta.setdefault("target", built.target)
+        return result
+
+    # ---- public API ----
+
+    async def chat(
+        self,
+        messages: list[dict],
+        *,
+        model: Optional[str] = None,
+        provider: Optional[str] = None,
+        modality: str = "chat",
+        base_url: Optional[str] = None,
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+        report: Optional[dict] = None,
+        **extra: Any,
+    ) -> dict:
+        async def call(p: Any, textra: dict) -> dict:
+            if isinstance(p, LocalComputeProvider):
+                return await p.chat(
+                    model=model, messages=messages, provider=provider,
+                    base_url=base_url, temperature=temperature,
+                    max_tokens=max_tokens, **extra,
+                )
+            kwargs = {
+                k: v for k, v in (
+                    ("temperature", temperature), ("max_tokens", max_tokens),
+                    *extra.items(), *textra.items(),
+                ) if v is not None
+            }
+            return await p.chat(model=model or "", messages=messages, **kwargs)
+
+        return await self._dispatch(modality, model, call, report=report)
+
+    async def _dispatch_stream(self, modality, model_id, make_stream, report=None):
+        """Streaming dispatch. Fallback happens **only before the first token** —
+        once any delta has reached the caller we never restart on another target
+        (the design's safe-streaming rule); a mid-stream failure is raised."""
+        targets = policies.resolve_targets(modality, model_id)
+        failures: list[dict] = []
+        tried_local = False
+        last_exc: Optional[Exception] = None
+
+        def _win(target: str, device_id: Optional[str]) -> None:
+            if report is None:
+                return
+            report["target"] = target
+            report["device_id"] = device_id
+            report["fell_back"] = bool(failures)
+            report["attempts"] = failures + [{"target": target, "ok": True}]
+            if failures:
+                report["reason"] = failures[0].get("reason")
+
+        async def _try(provider, extra, target, health_key):
+            first = True
+            async for delta in make_stream(provider, extra):
+                if first:
+                    self._cache.record(health_key, True)
+                    _win(target, (extra.get("routing") or {}).get("device_id"))
+                    first = False
+                yield delta
+            if first:  # completed with zero tokens — still a success
+                self._cache.record(health_key, True)
+                _win(target, (extra.get("routing") or {}).get("device_id"))
+
+        for target in targets:
+            offline = _device_offline_reason(target)
+            if offline is not None:
+                failures.append({"target": target, "ok": False, "reason": offline})
+                continue
+            built = providers.build_target(target)
+            if built is None:
+                failures.append({"target": target, "ok": False, "reason": "not available"})
+                continue
+            if not self._cache.allows(built.health_key):
+                failures.append({"target": target, "ok": False, "reason": "recently failed"})
+                continue
+            if built.health_key == "local":
+                tried_local = True
+            emitted = False
+            try:
+                async for delta in _try(built.provider, built.extra, built.target, built.health_key):
+                    emitted = True
+                    yield delta
+                return
+            except Exception as exc:
+                if emitted:
+                    self._cache.record(built.health_key, False)
+                    raise  # mid-stream — never restart
+                last_exc = exc
+                self._cache.record(built.health_key, False)
+                failures.append({"target": target, "ok": False, "reason": str(exc)[:140]})
+                continue
+
+        if not tried_local:
+            local = LocalComputeProvider()
+            emitted = False
+            try:
+                async for delta in _try(local, {}, "local", "local"):
+                    emitted = True
+                    yield delta
+                return
+            except Exception as exc:
+                if emitted:
+                    raise
+                last_exc = exc
+
+        if last_exc is not None:
+            raise last_exc
+        raise RuntimeError("no compute target available for this request")
+
+    async def chat_stream(
+        self,
+        messages: list[dict],
+        *,
+        model: Optional[str] = None,
+        provider: Optional[str] = None,
+        modality: str = "chat",
+        base_url: Optional[str] = None,
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+        report: Optional[dict] = None,
+        **extra: Any,
+    ):
+        def make_stream(p: Any, textra: dict):
+            if isinstance(p, LocalComputeProvider):
+                return p.chat_stream(
+                    model=model, messages=messages, provider=provider,
+                    base_url=base_url, temperature=temperature,
+                    max_tokens=max_tokens, **extra,
+                )
+            kwargs = {
+                k: v for k, v in (
+                    ("temperature", temperature), ("max_tokens", max_tokens),
+                    *extra.items(), *textra.items(),
+                ) if v is not None
+            }
+            return p.chat_stream(model=model or "", messages=messages, **kwargs)
+
+        async for delta in self._dispatch_stream(modality, model, make_stream, report=report):
+            yield delta
+
+    async def generate_image(
+        self, *, model: Optional[str] = None, modality: str = "image", **kwargs: Any
+    ) -> GeneratedMedia:
+        async def call(p: Any, textra: dict) -> GeneratedMedia:
+            return await p.generate_image(model=model, **{**kwargs, **textra})
+        return await self._dispatch(modality, model, call)
+
+    async def edit_image(
+        self, *, model: Optional[str] = None, modality: str = "edit", **kwargs: Any
+    ) -> GeneratedMedia:
+        async def call(p: Any, textra: dict) -> GeneratedMedia:
+            return await p.edit_image(model=model, **{**kwargs, **textra})
+        return await self._dispatch(modality, model, call)
+
+    async def generate_video(
+        self, *, model: Optional[str] = None, modality: str = "video", **kwargs: Any
+    ) -> GeneratedMedia:
+        async def call(p: Any, textra: dict) -> GeneratedMedia:
+            return await p.generate_video(model=model, **{**kwargs, **textra})
+        return await self._dispatch(modality, model, call)
+
+
+async def route_chat(
+    messages: list[dict],
+    *,
+    provider: str = "openai_compat",
+    temperature: float = 0.7,
+    max_tokens: int = 800,
+    base_url: Optional[str] = None,
+    model: Optional[str] = None,
+    modality: str = "chat",
+    report: Optional[dict] = None,
+) -> dict:
+    """Drop-in replacement for ``app.llm.chat`` that routes through the active
+    compute plan. Signature mirrors ``llm.chat`` exactly; in the default
+    (unconfigured / local) case this is the same call as before.
+
+    Pass a mutable ``report`` dict to receive routing diagnostics (which target
+    served the request, whether it fell back, and why) — see ``describe_target``.
+    """
+    return await ComputeRouter().chat(
+        messages,
+        model=model,
+        provider=provider,
+        modality=modality,
+        base_url=base_url,
+        temperature=temperature,
+        max_tokens=max_tokens,
+        report=report,
+    )
+
+
+def _device_offline_reason(target: str) -> Optional[str]:
+    """If ``target`` is a device the registry reports offline, return an
+    actionable reason ("Colab T4 offline — heartbeat expired 22s ago"); else
+    None. Gated on the Cloud-authoritative ``online`` flag so an infrequent sync
+    can't false-negative a device that's actually up — a live device that
+    momentarily fails is handled by the normal exception path instead."""
+    if not target.startswith("device:"):
+        return None
+    from . import registry
+    did = target.split(":", 1)[1]
+    dev = registry.get_device(did)
+    if dev is None or dev.online:
+        return None
+    name = dev.name or did
+    age = dev.heartbeat_age_s()
+    if age is None:
+        return f"{name} offline"
+    return f"{name} offline — heartbeat expired {int(age)}s ago"
+
+
+async def route_chat_stream(
+    messages: list[dict],
+    *,
+    provider: str = "openai_compat",
+    temperature: float = 0.7,
+    max_tokens: int = 800,
+    base_url: Optional[str] = None,
+    model: Optional[str] = None,
+    modality: str = "chat",
+    report: Optional[dict] = None,
+):
+    """Streaming counterpart of ``route_chat`` — yields assistant text deltas
+    through the active compute plan, with pre-first-token fallback."""
+    async for delta in ComputeRouter().chat_stream(
+        messages, model=model, provider=provider, modality=modality,
+        base_url=base_url, temperature=temperature, max_tokens=max_tokens,
+        report=report,
+    ):
+        yield delta
+
+
+def describe_target(target: Optional[str], device_id: Optional[str] = None) -> str:
+    """Human label for a routing target — 'This PC', 'Colab T4', 'OllaBridge
+    Cloud', a source name — resolved against the registry."""
+    if not target or target == "local":
+        return "This PC"
+    if target.startswith("ollabridge"):
+        return "OllaBridge Cloud"
+    from . import registry
+    if target.startswith("device:"):
+        did = target.split(":", 1)[1]
+        dev = registry.get_device(did)
+        return dev.name if dev and dev.name else f"Device {did}"
+    if target.startswith("source:"):
+        sid = target.split(":", 1)[1]
+        src = registry.get_source(sid)
+        return src.name if src and src.name else f"Source {sid}"
+    if target.startswith("provider:"):
+        return f"Provider {target.split(':', 1)[1]}"
+    return target
+
+
+def build_diagnostics(report: dict) -> Optional[dict]:
+    """Shape a route ``report`` into the ``compute`` block the chat API returns
+    (None when nothing was recorded)."""
+    target = report.get("target")
+    if not target:
+        return None
+    return {
+        "target": target,
+        "device_id": report.get("device_id"),
+        "label": describe_target(target, report.get("device_id")),
+        "fell_back": bool(report.get("fell_back")),
+        "reason": report.get("reason"),
+    }

--- a/backend/app/compute/routes.py
+++ b/backend/app/compute/routes.py
@@ -24,3 +24,12 @@ async def get_status() -> dict:
 async def get_mode() -> dict:
     from app.config import HOMEPILOT_COMPUTE_MODE
     return {"configured": HOMEPILOT_COMPUTE_MODE, "effective": await resolve_mode()}
+
+
+@router.get("/readiness")
+async def get_readiness() -> dict:
+    """Production-readiness of the compute feature — what an operator must set
+    before exposing HomePilot to the world (credential encryption, API key,
+    canonical Cloud URL). See docs/COMPUTE_PRODUCTION.md."""
+    from .readiness import production_readiness
+    return production_readiness()

--- a/backend/app/compute/routes_admin.py
+++ b/backend/app/compute/routes_admin.py
@@ -1,0 +1,239 @@
+"""
+Compute admin routes (PR 2).
+
+CRUD for the persisted registry — sources, per-model routes, model manifests —
+plus the settings that replaced the env-only global flags, and a
+``/resolve`` endpoint that explains how a given request would be routed. These
+back the settings UI (PR 3); they are additive and do not touch existing
+generation routes.
+
+Credentials are write-only: a source stores only a ``credential_ref``; the
+secret is posted separately and kept server-side (``secrets``), never returned.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import httpx
+from fastapi import APIRouter, Body, Cookie, Depends, Header, HTTPException
+
+from ..auth import require_api_key
+from . import registry, secrets
+from .netguard import UnsafeEndpointError, validate_outbound_url
+from .schemas import (
+    ComputeSettings,
+    ComputeSource,
+    ModelManifest,
+    ModelRoute,
+)
+
+# Auth follows the app convention (Depends(require_api_key)); the substantive
+# hardening for these routes is the SSRF guard on custom endpoint URLs below.
+router = APIRouter(
+    prefix="/compute/admin", tags=["compute-admin"],
+    dependencies=[Depends(require_api_key)],
+)
+
+
+# ---- Cloud sync -------------------------------------------------------------
+
+@router.post("/sync")
+async def sync_cloud(
+    authorization: Optional[str] = Header(default=None),
+    homepilot_session: Optional[str] = Cookie(default=None),
+) -> dict:
+    """Pull the signed-in user's paired devices + advertised models from
+    OllaBridge Cloud into the registry, so Resources and the per-model selector
+    show live nodes. Credentials are resolved server-side; the browser never
+    holds a cloud token. Reports ``linked=False`` (not an error) when unlinked or
+    the cloud is unreachable."""
+    from . import sync as cloud_sync
+    from ..mirror_proxy import _require_user, _resolve_cloud_credentials
+
+    try:
+        user = _require_user(authorization, homepilot_session)
+    except HTTPException as exc:
+        if exc.status_code == 401:
+            return {"ok": False, "linked": False, "reason": "Sign in to sync your devices.", "devices": 0, "models": 0}
+        raise
+    try:
+        base, token = _resolve_cloud_credentials(user)
+    except HTTPException as exc:
+        if exc.status_code == 503:
+            return {"ok": False, "linked": False, "reason": "Link your OllaBridge account first.", "devices": 0, "models": 0}
+        raise
+
+    async def fetch(path: str) -> tuple[int, Any]:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(10.0, connect=5.0)) as client:
+            r = await client.get(
+                f"{base}{path}",
+                headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+            )
+            try:
+                body = r.json()
+            except Exception:
+                body = None
+            return r.status_code, body
+
+    return await cloud_sync.sync_from_cloud(base, fetch=fetch)
+
+
+# ---- sources ----------------------------------------------------------------
+
+@router.get("/sources")
+async def list_sources() -> dict:
+    return {"sources": [s.to_dict() for s in registry.list_sources()]}
+
+
+@router.post("/sources")
+async def upsert_source(body: dict = Body(...)) -> dict:
+    if not body.get("id"):
+        raise HTTPException(400, "source.id is required")
+    # SSRF guard: refuse to persist a source pointing at a blocked endpoint.
+    try:
+        validate_outbound_url(body.get("base_url"))
+    except UnsafeEndpointError as exc:
+        raise HTTPException(400, str(exc))
+    # A secret may be supplied inline; it is stored out-of-band and replaced by a ref.
+    secret = body.pop("credential", None)
+    source = ComputeSource.from_dict(body)
+    if secret:
+        source.credential_ref = secrets.put_secret(secret, ref=source.credential_ref)
+    registry.upsert_source(source)
+    return {"source": source.to_dict()}
+
+
+@router.delete("/sources/{source_id}")
+async def delete_source(source_id: str) -> dict:
+    existing = registry.get_source(source_id)
+    if existing and existing.credential_ref:
+        secrets.delete_secret(existing.credential_ref)
+    registry.delete_source(source_id)
+    return {"deleted": source_id}
+
+
+@router.post("/sources/{source_id}/test")
+async def test_source(source_id: str) -> dict:
+    """Probe a source's reachability by building its provider and calling
+    ``available()``. Returns a plain-language result for the Sources UI."""
+    from . import providers
+    source = registry.get_source(source_id)
+    if source is None:
+        raise HTTPException(404, "source not found")
+    # Re-check before dialing (a stored source, or DNS, may have changed).
+    try:
+        validate_outbound_url(source.base_url)
+    except UnsafeEndpointError as exc:
+        return {"ok": False, "reason": str(exc)}
+    built = providers.build_target(f"source:{source_id}")
+    if built is None:
+        return {"ok": False, "reason": "This source can't be built (missing URL/credential or unsupported kind)."}
+    try:
+        ok = await built.provider.available()
+        return {
+            "ok": bool(ok),
+            "reason": "Reachable." if ok else "Unreachable — check the URL, credential, or that the endpoint is up.",
+        }
+    except Exception as exc:  # never 500 a connectivity probe
+        return {"ok": False, "reason": f"Probe failed: {exc}"}
+
+
+@router.post("/sources/{source_id}/credential")
+async def set_source_credential(source_id: str, body: dict = Body(...)) -> dict:
+    source = registry.get_source(source_id)
+    if source is None:
+        raise HTTPException(404, "source not found")
+    secret = (body or {}).get("credential") or ""
+    if not secret:
+        raise HTTPException(400, "credential is required")
+    source.credential_ref = secrets.put_secret(secret, ref=source.credential_ref)
+    registry.upsert_source(source)
+    return {"credential_ref": source.credential_ref}
+
+
+# ---- devices ----------------------------------------------------------------
+
+@router.get("/devices")
+async def list_devices(source_id: Optional[str] = None) -> dict:
+    settings = registry.load_settings()
+    ttl = settings.device_heartbeat_ttl_s
+    devices = []
+    for d in registry.list_devices(source_id):
+        row = d.to_dict()
+        row["online_effective"] = d.is_online(ttl_s=ttl)
+        row["heartbeat_age_s"] = d.heartbeat_age_s()
+        devices.append(row)
+    return {"devices": devices}
+
+
+# ---- manifests --------------------------------------------------------------
+
+@router.get("/models")
+async def list_models() -> dict:
+    return {"models": [m.to_dict() for m in registry.list_manifests()]}
+
+
+@router.post("/models")
+async def upsert_model(body: dict = Body(...)) -> dict:
+    if not body.get("id"):
+        raise HTTPException(400, "model.id is required")
+    manifest = ModelManifest.from_dict(body)
+    registry.upsert_manifest(manifest)
+    return {"model": manifest.to_dict()}
+
+
+@router.delete("/models/{model_id}")
+async def delete_model(model_id: str) -> dict:
+    registry.delete_manifest(model_id)
+    return {"deleted": model_id}
+
+
+# ---- routes -----------------------------------------------------------------
+
+@router.get("/routes")
+async def list_routes() -> dict:
+    return {"routes": [r.to_dict() for r in registry.list_routes()]}
+
+
+@router.post("/routes")
+async def upsert_route(body: dict = Body(...)) -> dict:
+    for required in ("modality", "model_id", "primary_target"):
+        if not body.get(required):
+            raise HTTPException(400, f"route.{required} is required")
+    route = ModelRoute.from_dict(body)
+    registry.upsert_route(route)
+    return {"route": route.to_dict()}
+
+
+@router.delete("/routes/{modality}/{model_id}")
+async def delete_route(modality: str, model_id: str) -> dict:
+    registry.delete_route(model_id, modality)
+    return {"deleted": {"modality": modality, "model_id": model_id}}
+
+
+# ---- settings ---------------------------------------------------------------
+
+@router.get("/settings")
+async def get_settings() -> dict:
+    return {"settings": registry.load_settings().to_dict()}
+
+
+@router.put("/settings")
+async def put_settings(body: dict = Body(...)) -> dict:
+    # Overlay onto current (env-seeded) settings so partial updates are allowed.
+    current = registry.load_settings().to_dict()
+    current.update({k: v for k, v in (body or {}).items() if v is not None})
+    if body.get("modality_defaults") is not None:
+        current["modality_defaults"] = body["modality_defaults"]
+    settings = ComputeSettings.from_dict(current)
+    registry.save_settings(settings)
+    return {"settings": settings.to_dict()}
+
+
+# ---- routing explain --------------------------------------------------------
+
+@router.get("/resolve")
+async def resolve(modality: str, model_id: Optional[str] = None) -> dict:
+    from . import policies
+    return policies.explain(modality, model_id)

--- a/backend/app/compute/schemas.py
+++ b/backend/app/compute/schemas.py
@@ -1,0 +1,284 @@
+"""
+Compute Sources & Routing — data model (PR 2).
+
+Plain dataclasses (no pydantic dependency) for the entities the registry
+persists and the router resolves against. Each has ``from_dict``/``to_dict`` so
+they round-trip through SQLite JSON columns and the admin API.
+
+Entities mirror the design doc:
+
+* ``ComputeSource``  — a place work can run (local, an OllaBridge relay, an
+  OpenAI-compatible endpoint, …).
+* ``ComputeDevice``  — a concrete machine advertised by a source (a Colab T4, a
+  home RTX 4090). Devices are reported by the source; the registry caches them.
+* ``ModelManifest``  — what a model *is* on a device: runtime, capabilities,
+  digest, VRAM need. Capabilities come from the manifest, not name-guessing.
+* ``ModelRoute``     — a per-model (or per-modality-default) routing decision:
+  where to run it, what to fall back to, and the policy that governs it.
+* ``ComputeSettings``— global, persisted settings that used to be env-only
+  flags (compute mode, burst gating, cloud defaults) plus per-modality defaults.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import asdict, dataclass, field
+from typing import Any, Optional
+
+# ---- controlled vocabularies (kept as plain strings for forward-compat) -----
+
+SourceKind = str      # local | ollabridge | openai_compatible | comfyui | ...
+ExecutionType = str   # local | direct | relay
+Runtime = str         # ollama | vllm | comfyui | openai_api
+Capability = str      # chat | vision | image | video | edit | multimodal
+Modality = str        # chat | multimodal | image | video | edit
+Strategy = str        # pinned | prefer_local | prefer_remote | lowest_cost
+Privacy = str         # local_only | private_nodes | hosted_allowed
+
+VALID_STRATEGIES = ("pinned", "prefer_local", "prefer_remote", "lowest_cost")
+VALID_PRIVACY = ("local_only", "private_nodes", "hosted_allowed")
+
+
+def _now() -> float:
+    return time.time()
+
+
+@dataclass
+class ComputeSource:
+    id: str
+    name: str
+    kind: SourceKind = "local"
+    base_url: Optional[str] = None
+    credential_ref: Optional[str] = None  # key into the secrets store, never the secret
+    enabled: bool = True
+    execution_type: ExecutionType = "local"
+    meta: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "ComputeSource":
+        return cls(
+            id=d["id"],
+            name=d.get("name") or d["id"],
+            kind=d.get("kind", "local"),
+            base_url=d.get("base_url"),
+            credential_ref=d.get("credential_ref"),
+            enabled=bool(d.get("enabled", True)),
+            execution_type=d.get("execution_type", "local"),
+            meta=dict(d.get("meta") or {}),
+        )
+
+
+@dataclass
+class ComputeDevice:
+    id: str
+    source_id: str
+    name: str = ""
+    online: bool = False
+    ephemeral: bool = False
+    gpu_name: Optional[str] = None
+    vram_mb: Optional[int] = None
+    utilization: Optional[float] = None
+    capacity: int = 1
+    active_jobs: int = 0
+    last_heartbeat: Optional[float] = None  # epoch seconds
+
+    def heartbeat_age_s(self, now: Optional[float] = None) -> Optional[float]:
+        if self.last_heartbeat is None:
+            return None
+        return (now or _now()) - self.last_heartbeat
+
+    def is_online(self, ttl_s: float = 45.0, now: Optional[float] = None) -> bool:
+        """Online if the flag is set *and* the heartbeat hasn't expired."""
+        if not self.online:
+            return False
+        age = self.heartbeat_age_s(now)
+        return age is None or age <= ttl_s
+
+    def has_capacity(self) -> bool:
+        return self.capacity <= 0 or self.active_jobs < self.capacity
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "ComputeDevice":
+        return cls(
+            id=d["id"],
+            source_id=d["source_id"],
+            name=d.get("name", ""),
+            online=bool(d.get("online", False)),
+            ephemeral=bool(d.get("ephemeral", False)),
+            gpu_name=d.get("gpu_name"),
+            vram_mb=d.get("vram_mb"),
+            utilization=d.get("utilization"),
+            capacity=int(d.get("capacity", 1)),
+            active_jobs=int(d.get("active_jobs", 0)),
+            last_heartbeat=d.get("last_heartbeat"),
+        )
+
+
+@dataclass
+class ModelManifest:
+    id: str
+    runtime: Runtime = "ollama"
+    capabilities: list[Capability] = field(default_factory=list)
+    device_ids: list[str] = field(default_factory=list)
+    digest: Optional[str] = None
+    minimum_vram_mb: Optional[int] = None
+    workflow_version: Optional[str] = None
+
+    def supports(self, capability: Capability) -> bool:
+        return capability in self.capabilities
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "ModelManifest":
+        return cls(
+            id=d["id"],
+            runtime=d.get("runtime", "ollama"),
+            capabilities=list(d.get("capabilities") or []),
+            device_ids=list(d.get("device_ids") or []),
+            digest=d.get("digest"),
+            minimum_vram_mb=d.get("minimum_vram_mb"),
+            workflow_version=d.get("workflow_version"),
+        )
+
+
+@dataclass
+class ModelRoute:
+    """A per-model routing decision. ``model_id`` is the key; ``modality`` scopes
+    it (a name can differ across image/chat)."""
+    modality: Modality
+    model_id: str
+    primary_target: str
+    fallback_targets: list[str] = field(default_factory=list)
+    strategy: Strategy = "pinned"
+    max_queue_seconds: Optional[int] = None
+    max_cost_usd: Optional[float] = None
+    privacy: Privacy = "private_nodes"
+
+    def normalized_strategy(self) -> Strategy:
+        return self.strategy if self.strategy in VALID_STRATEGIES else "pinned"
+
+    def normalized_privacy(self) -> Privacy:
+        return self.privacy if self.privacy in VALID_PRIVACY else "private_nodes"
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "ModelRoute":
+        return cls(
+            modality=d["modality"],
+            model_id=d["model_id"],
+            primary_target=d["primary_target"],
+            fallback_targets=list(d.get("fallback_targets") or []),
+            strategy=d.get("strategy", "pinned"),
+            max_queue_seconds=d.get("max_queue_seconds"),
+            max_cost_usd=d.get("max_cost_usd"),
+            privacy=d.get("privacy", "private_nodes"),
+        )
+
+
+@dataclass
+class ModalityDefault:
+    """Default routing for a whole modality when no per-model route matches."""
+    modality: Modality
+    strategy: Strategy = "prefer_local"
+    target: Optional[str] = None
+    fallback_targets: list[str] = field(default_factory=list)
+    privacy: Privacy = "private_nodes"
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "ModalityDefault":
+        return cls(
+            modality=d["modality"],
+            strategy=d.get("strategy", "prefer_local"),
+            target=d.get("target"),
+            fallback_targets=list(d.get("fallback_targets") or []),
+            privacy=d.get("privacy", "private_nodes"),
+        )
+
+
+@dataclass
+class ComputeSettings:
+    """Persisted global settings — the successor to the env-only flags.
+
+    ``from_env()`` seeds these from ``app.config`` so an unconfigured install
+    behaves exactly as before; the registry persists overrides on top.
+    """
+    compute_mode: str = "local"                 # local | ollabridge_cloud | auto
+    burst_requires_premium: bool = False
+    premium_enabled: bool = False
+    cloud_url: Optional[str] = None
+    cloud_image_model: str = "flux-schnell"
+    cloud_video_model: str = "ltx-video"
+    device_heartbeat_ttl_s: float = 45.0
+    modality_defaults: dict[str, ModalityDefault] = field(default_factory=dict)
+    # PR 5 — cost-aware routing. Budget is a per-request USD cap (None = no cap).
+    # The catalog is a timestamped, operator-supplied price map (never hardcoded);
+    # it can be synced from OllaBridge's provider registry.
+    max_cost_usd_per_request: Optional[float] = None
+    cost_catalog: dict[str, Any] = field(default_factory=dict)
+
+    def default_for(self, modality: Modality) -> Optional[ModalityDefault]:
+        return self.modality_defaults.get(modality)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "compute_mode": self.compute_mode,
+            "burst_requires_premium": self.burst_requires_premium,
+            "premium_enabled": self.premium_enabled,
+            "cloud_url": self.cloud_url,
+            "cloud_image_model": self.cloud_image_model,
+            "cloud_video_model": self.cloud_video_model,
+            "device_heartbeat_ttl_s": self.device_heartbeat_ttl_s,
+            "modality_defaults": {
+                k: v.to_dict() for k, v in self.modality_defaults.items()
+            },
+            "max_cost_usd_per_request": self.max_cost_usd_per_request,
+            "cost_catalog": self.cost_catalog,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "ComputeSettings":
+        defaults = {
+            k: ModalityDefault.from_dict({**v, "modality": v.get("modality", k)})
+            for k, v in (d.get("modality_defaults") or {}).items()
+        }
+        return cls(
+            compute_mode=(d.get("compute_mode") or "local").strip().lower(),
+            burst_requires_premium=bool(d.get("burst_requires_premium", False)),
+            premium_enabled=bool(d.get("premium_enabled", False)),
+            cloud_url=d.get("cloud_url"),
+            cloud_image_model=d.get("cloud_image_model", "flux-schnell"),
+            cloud_video_model=d.get("cloud_video_model", "ltx-video"),
+            device_heartbeat_ttl_s=float(d.get("device_heartbeat_ttl_s", 45.0)),
+            modality_defaults=defaults,
+            max_cost_usd_per_request=d.get("max_cost_usd_per_request"),
+            cost_catalog=dict(d.get("cost_catalog") or {}),
+        )
+
+    @classmethod
+    def from_env(cls) -> "ComputeSettings":
+        """Seed from ``app.config`` (deployment defaults)."""
+        from app import config
+        mode = (getattr(config, "HOMEPILOT_COMPUTE_MODE", "local") or "local").strip().lower()
+        if mode not in ("local", "ollabridge_cloud", "auto"):
+            mode = "local"
+        return cls(
+            compute_mode=mode,
+            burst_requires_premium=bool(getattr(config, "COMPUTE_BURST_REQUIRES_PREMIUM", False)),
+            premium_enabled=bool(getattr(config, "PREMIUM_COMPUTE_ENABLED", False)),
+            cloud_url=getattr(config, "OLLABRIDGE_CLOUD_URL", None) or None,
+            cloud_image_model=getattr(config, "OLLABRIDGE_CLOUD_IMAGE_MODEL", "flux-schnell"),
+            cloud_video_model=getattr(config, "OLLABRIDGE_CLOUD_VIDEO_MODEL", "ltx-video"),
+        )

--- a/backend/app/compute/secrets.py
+++ b/backend/app/compute/secrets.py
@@ -1,0 +1,139 @@
+"""
+Compute credential store (PR 2).
+
+Sources that talk to a remote endpoint (an OpenAI-compatible API, a hosted
+provider) need a credential. We never keep that in the frontend or in the
+``ComputeSource`` row — the source stores only a ``credential_ref`` (an opaque
+key), and the actual secret lives here, server-side.
+
+Encryption is opt-in and mirrors ``app.cloud_tokens``: if ``cryptography`` is
+installed and ``HOMEPILOT_COMPUTE_SECRET_KEY`` (a Fernet key) is set, values are
+encrypted at rest ("f:"); otherwise they are stored server-side as-is ("p:").
+Either way the secret is out of the browser — the primary goal.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import time
+import uuid
+from typing import Optional
+
+from ..storage import _get_db_path
+
+_TABLE = "compute_secrets"
+_fernet_cache: object = None
+
+
+def _fernet():
+    global _fernet_cache
+    if _fernet_cache is not None:
+        return _fernet_cache or None
+    key = os.getenv("HOMEPILOT_COMPUTE_SECRET_KEY", "").strip()
+    if not key:
+        _fernet_cache = False
+        return None
+    try:
+        from cryptography.fernet import Fernet
+        _fernet_cache = Fernet(key.encode())
+        return _fernet_cache
+    except Exception:
+        _fernet_cache = False
+        return None
+
+
+def _encode(secret: str) -> str:
+    f = _fernet()
+    if f:
+        try:
+            return "f:" + f.encrypt(secret.encode()).decode()
+        except Exception:
+            pass
+    return "p:" + secret
+
+
+def _decode(stored: str) -> Optional[str]:
+    if stored.startswith("f:"):
+        f = _fernet()
+        if not f:
+            return None
+        try:
+            return f.decrypt(stored[2:].encode()).decode()
+        except Exception:
+            return None
+    if stored.startswith("p:"):
+        return stored[2:]
+    return stored  # legacy plaintext
+
+
+def ensure_table() -> None:
+    con = sqlite3.connect(_get_db_path())
+    try:
+        con.execute(
+            f"""
+            CREATE TABLE IF NOT EXISTS {_TABLE} (
+                ref        TEXT PRIMARY KEY,
+                secret_enc TEXT NOT NULL,
+                updated_at REAL NOT NULL
+            )
+            """
+        )
+        con.commit()
+    finally:
+        con.close()
+
+
+def put_secret(secret: str, *, ref: Optional[str] = None) -> str:
+    """Store (upsert) a secret and return its ref. Generates a ref if omitted."""
+    ref = ref or f"cred_{uuid.uuid4().hex[:16]}"
+    if not secret:
+        return ref
+    ensure_table()
+    con = sqlite3.connect(_get_db_path())
+    try:
+        con.execute(
+            f"INSERT INTO {_TABLE}(ref, secret_enc, updated_at) VALUES (?,?,?) "
+            f"ON CONFLICT(ref) DO UPDATE SET secret_enc=excluded.secret_enc, "
+            f"updated_at=excluded.updated_at",
+            (ref, _encode(secret), time.time()),
+        )
+        con.commit()
+    finally:
+        con.close()
+    return ref
+
+
+def get_secret(ref: Optional[str]) -> Optional[str]:
+    """Return the secret for ``ref`` (decrypted), or None. Never raises."""
+    if not ref:
+        return None
+    try:
+        ensure_table()
+        con = sqlite3.connect(_get_db_path())
+        try:
+            row = con.execute(
+                f"SELECT secret_enc FROM {_TABLE} WHERE ref = ?", (ref,)
+            ).fetchone()
+        finally:
+            con.close()
+    except Exception:
+        return None
+    if not row or not row[0]:
+        return None
+    return _decode(row[0])
+
+
+def delete_secret(ref: Optional[str]) -> None:
+    if not ref:
+        return
+    try:
+        ensure_table()
+        con = sqlite3.connect(_get_db_path())
+        try:
+            con.execute(f"DELETE FROM {_TABLE} WHERE ref = ?", (ref,))
+            con.commit()
+        finally:
+            con.close()
+    except Exception:
+        pass

--- a/backend/app/compute/stream_routes.py
+++ b/backend/app/compute/stream_routes.py
@@ -1,0 +1,65 @@
+"""
+Streaming chat endpoint (P1 — token streaming).
+
+Additive Server-Sent-Events route that streams a routed chat token-by-token, so
+the UI can render a live typewriter and show *where* it ran when it finishes. The
+existing non-streaming ``/chat`` is untouched.
+
+Wire format (one JSON object per SSE ``data:`` frame):
+
+    {"delta": "Hel"}                      # token deltas, in order
+    {"error": "..."}                      # a failure surfaced mid-stream
+    {"done": true, "compute": {...}}      # terminal frame + route diagnostics
+
+Fallback happens only before the first token (see ``ComputeRouter.chat_stream``),
+so a live typewriter never restarts on another device.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from fastapi import APIRouter, Body, Depends
+from fastapi.responses import StreamingResponse
+
+from ..auth import require_api_key
+from .netguard import is_safe_outbound_url
+from .router import build_diagnostics, route_chat_stream
+
+router = APIRouter(
+    prefix="/v1/compute", tags=["compute-stream"],
+    dependencies=[Depends(require_api_key)],
+)
+
+
+@router.post("/chat/stream")
+async def chat_stream_endpoint(body: dict = Body(...)) -> StreamingResponse:
+    messages = body.get("messages") or []
+    model = body.get("model")
+    provider = body.get("provider") or "openai_compat"
+    modality = body.get("modality") or "chat"
+    base_url = body.get("base_url")
+    if base_url and not is_safe_outbound_url(base_url):
+        base_url = None  # ignore a blocked base_url rather than dial it
+    temperature = float(body.get("temperature", 0.7))
+    max_tokens = int(body.get("max_tokens", 800))
+    report: dict = {}
+
+    async def gen() -> Any:
+        try:
+            async for delta in route_chat_stream(
+                messages, provider=provider, model=model, modality=modality,
+                base_url=base_url, temperature=temperature, max_tokens=max_tokens,
+                report=report,
+            ):
+                yield f"data: {json.dumps({'delta': delta})}\n\n"
+        except Exception as exc:  # surfaced, not a 500 — the stream already started
+            yield f"data: {json.dumps({'error': str(exc)})}\n\n"
+        yield f"data: {json.dumps({'done': True, 'compute': build_diagnostics(report)})}\n\n"
+
+    return StreamingResponse(
+        gen(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )

--- a/backend/app/compute/sync.py
+++ b/backend/app/compute/sync.py
@@ -1,0 +1,207 @@
+"""
+Cloud → registry sync (P0-1).
+
+The registry only becomes *real* when it is fed by OllaBridge Cloud: a paired
+Colab/RunPod/home node advertises itself and its models to Cloud over the
+outbound relay, and HomePilot must pull that inventory into its own
+``ComputeDevice`` / ``ModelManifest`` tables so the Resources panel and the
+per-model selector show live nodes and route to them.
+
+This module maps Cloud's ``GET /v1/devices`` (paired devices + heartbeat/GPU)
+and ``GET /ollama/v1/models`` (advertised models, tagged to a device) into the
+registry. Capabilities come from what the node/device advertises — never from
+guessing model names.
+
+The HTTP fetch is injected (``fetch(path) -> (status, json)``) so the mapping
+and reconcile logic are unit-testable without a live Cloud; the route supplies a
+real httpx-backed fetcher with the server-side cloud token.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable, Optional
+
+from . import registry
+from .schemas import ComputeDevice, ComputeSource, ModelManifest
+
+# The single logical source that represents "devices reached via OllaBridge
+# Cloud". Its devices are the user's paired nodes.
+CLOUD_SOURCE_ID = "ollabridge-cloud"
+
+Fetch = Callable[[str], Awaitable[tuple[int, Any]]]
+
+_RELAY_OWNER_RE = re.compile(r"^relay:(?P<dev>[^:]+)")
+# Which model-capabilities imply which routing modality-capabilities.
+_CHAT_CAPS = {"chat", "text", "completion"}
+_VISION_CAPS = {"vision", "multimodal", "image-input"}
+
+
+def ensure_cloud_source(base_url: Optional[str] = None) -> ComputeSource:
+    """Ensure the ollabridge Cloud source row exists (idempotent)."""
+    existing = registry.get_source(CLOUD_SOURCE_ID)
+    source = ComputeSource(
+        id=CLOUD_SOURCE_ID,
+        name="OllaBridge Cloud",
+        kind="ollabridge",
+        base_url=base_url or (existing.base_url if existing else None),
+        enabled=existing.enabled if existing else True,
+        execution_type="relay",
+        meta={"managed": True},
+    )
+    return registry.upsert_source(source)
+
+
+def _parse_last_seen(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        s = str(value).replace("Z", "+00:00")
+        return datetime.fromisoformat(s).timestamp()
+    except Exception:
+        return None
+
+
+def map_device(cloud_dev: dict, *, now: Optional[float] = None) -> ComputeDevice:
+    """Cloud device record → registry ComputeDevice (defensive about shape)."""
+    now = now or time.time()
+    gpu = cloud_dev.get("gpu") if isinstance(cloud_dev.get("gpu"), dict) else {}
+    gpu_name = gpu.get("name") or cloud_dev.get("gpu_name")
+    vram_mb = gpu.get("vram_mb") if gpu else cloud_dev.get("vram_mb")
+    online = bool(cloud_dev.get("online", False))
+    last_seen = _parse_last_seen(cloud_dev.get("last_seen") or cloud_dev.get("last_heartbeat"))
+    return ComputeDevice(
+        id=str(cloud_dev.get("id")),
+        source_id=CLOUD_SOURCE_ID,
+        name=cloud_dev.get("name") or str(cloud_dev.get("id")),
+        online=online,
+        ephemeral=bool(cloud_dev.get("ephemeral", False)),
+        gpu_name=gpu_name,
+        vram_mb=int(vram_mb) if vram_mb is not None else None,
+        capacity=int(cloud_dev.get("capacity", 1)),
+        active_jobs=int(cloud_dev.get("active_jobs", 0)),
+        # A device advertising over the relay is alive now; prefer the reported
+        # last_seen, else stamp now when online so heartbeat-age reads correctly.
+        last_heartbeat=last_seen if last_seen is not None else (now if online else None),
+    )
+
+
+def _device_id_of(model: dict) -> str:
+    for key in ("device_id", "deviceId"):
+        val = model.get(key)
+        if val:
+            return str(val)
+    m = _RELAY_OWNER_RE.match(str(model.get("owned_by") or ""))
+    return m.group("dev") if m else ""
+
+
+def _caps_for(device_caps: list[str], model: dict) -> list[str]:
+    """Manifest-driven capabilities: prefer the model's own advertised caps,
+    then the device's; fall back to chat. No name-guessing."""
+    raw = model.get("capabilities") or device_caps or []
+    caps: list[str] = []
+    lowered = {str(c).lower() for c in raw}
+    if lowered & _VISION_CAPS:
+        caps.append("multimodal")
+    if not caps or (lowered & _CHAT_CAPS):
+        if "chat" not in caps:
+            caps.insert(0, "chat")
+    return caps or ["chat"]
+
+
+def map_manifests(
+    models_payload: Any, device_caps: dict[str, list[str]]
+) -> list[ModelManifest]:
+    """Advertised models → manifests, grouped by owning device."""
+    data = models_payload.get("data") if isinstance(models_payload, dict) else models_payload
+    if not isinstance(data, list):
+        return []
+    by_id: dict[str, ModelManifest] = {}
+    for m in data:
+        if not isinstance(m, dict):
+            continue
+        source = m.get("x_source") or m.get("source")
+        if source not in (None, "shared_device"):
+            # Only the user's own shared-device models are node inventory.
+            continue
+        dev_id = _device_id_of(m)
+        mid = m.get("id")
+        if not (dev_id and mid):
+            continue
+        caps = _caps_for(device_caps.get(dev_id, []), m)
+        man = by_id.get(mid)
+        if man is None:
+            man = ModelManifest(
+                id=mid,
+                runtime=str(m.get("runtime") or "ollama"),
+                capabilities=caps,
+                device_ids=[dev_id],
+                digest=m.get("digest"),
+            )
+            by_id[mid] = man
+        else:
+            if dev_id not in man.device_ids:
+                man.device_ids.append(dev_id)
+            for c in caps:
+                if c not in man.capabilities:
+                    man.capabilities.append(c)
+    return list(by_id.values())
+
+
+async def sync_from_cloud(base_url: str, *, fetch: Fetch) -> dict:
+    """Pull devices + advertised models from Cloud into the registry.
+
+    Returns a summary the UI shows: how many devices/models synced, and whether
+    the account is linked/reachable. Never raises for an unreachable Cloud — it
+    reports ``linked=False`` so the UI can prompt a re-link.
+    """
+    ensure_cloud_source(base_url)
+
+    try:
+        dev_status, dev_payload = await fetch("/v1/devices")
+        mdl_status, mdl_payload = await fetch("/ollama/v1/models")
+    except Exception as exc:
+        return {"ok": False, "linked": False, "reason": f"Cloud unreachable: {exc}",
+                "devices": 0, "models": 0}
+
+    if dev_status == 401 or mdl_status == 401:
+        return {"ok": False, "linked": False, "reason": "Cloud rejected the token — re-link your account.",
+                "devices": 0, "models": 0}
+
+    cloud_devices = dev_payload if isinstance(dev_payload, list) else []
+    device_caps: dict[str, list[str]] = {}
+    reported_ids: set[str] = set()
+
+    for cd in cloud_devices:
+        if not isinstance(cd, dict) or not cd.get("id"):
+            continue
+        dev = map_device(cd)
+        registry.upsert_device(dev)
+        reported_ids.add(dev.id)
+        caps = cd.get("capabilities")
+        if isinstance(caps, list):
+            device_caps[dev.id] = [str(c) for c in caps]
+
+    # Reconcile: devices we previously synced from Cloud that are no longer
+    # reported are marked offline (never deleted — an offline device keeps its
+    # routes and can come back).
+    for existing in registry.list_devices(CLOUD_SOURCE_ID):
+        if existing.id not in reported_ids and existing.online:
+            existing.online = False
+            registry.upsert_device(existing)
+
+    manifests = map_manifests(mdl_payload, device_caps)
+    for man in manifests:
+        registry.upsert_manifest(man)
+
+    return {
+        "ok": True,
+        "linked": True,
+        "devices": len(reported_ids),
+        "models": len(manifests),
+        "source_id": CLOUD_SOURCE_ID,
+    }

--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -216,7 +216,7 @@ async def _process_summarize_session(job: Dict[str, Any]) -> None:
 
     # Use LLM to generate summary
     try:
-        from .llm import chat as llm_chat
+        from .compute import route_chat
 
         summary_prompt = [
             {
@@ -230,7 +230,7 @@ async def _process_summarize_session(job: Dict[str, Any]) -> None:
             {"role": "user", "content": f"Summarize this conversation:\n\n{transcript}"},
         ]
 
-        response = await llm_chat(
+        response = await route_chat(
             summary_prompt,
             temperature=0.3,
             max_tokens=150,
@@ -292,7 +292,7 @@ async def _process_extract_memory(job: Dict[str, Any]) -> None:
     transcript = "\n".join(transcript_lines)
 
     try:
-        from .llm import chat as llm_chat
+        from .compute import route_chat
 
         extract_prompt = [
             {
@@ -318,7 +318,7 @@ Return ONLY the JSON array, no markdown or explanation.""",
             {"role": "user", "content": f"Extract memories from:\n\n{transcript}"},
         ]
 
-        response = await llm_chat(
+        response = await route_chat(
             extract_prompt,
             temperature=0.1,
             max_tokens=500,

--- a/backend/app/llm.py
+++ b/backend/app/llm.py
@@ -808,3 +808,59 @@ async def chat(
         base_url=base_url,
         model=model,
     )
+
+
+async def stream_chat(
+    messages: List[Dict[str, Any]],
+    *,
+    provider: ProviderName = "openai_compat",
+    temperature: float = 0.7,
+    max_tokens: int = 800,
+    base_url: Optional[str] = None,
+    model: Optional[str] = None,
+):
+    """Yield assistant text deltas as they arrive (P1 — token streaming).
+
+    Ollama streams natively over ``/api/chat`` (NDJSON, ``message.content``
+    deltas). For every other provider we don't have a streaming adapter yet, so
+    we degrade gracefully: run the normal non-streaming ``chat`` and yield the
+    whole reply as a single chunk. Callers get a uniform async-iterator either
+    way, so the streaming path never breaks a provider it can't stream.
+    """
+    if provider == "ollama":
+        base = (base_url or OLLAMA_BASE_URL).rstrip("/")
+        mdl = (model or OLLAMA_MODEL).strip()
+        payload = {
+            "model": mdl,
+            "messages": [{"role": m["role"], "content": m["content"]} for m in messages],
+            "stream": True,
+            "keep_alive": os.getenv("OLLAMA_KEEP_ALIVE", "30m"),
+            "options": {"temperature": float(temperature), "num_predict": int(max_tokens)},
+        }
+        if is_thinking_model(mdl):
+            payload["think"] = False
+        async with httpx.AsyncClient(timeout=_timeout()) as client:
+            async with client.stream("POST", f"{base}/api/chat", json=payload) as resp:
+                resp.raise_for_status()
+                async for line in resp.aiter_lines():
+                    if not line.strip():
+                        continue
+                    try:
+                        obj = json.loads(line)
+                    except Exception:
+                        continue
+                    delta = (obj.get("message") or {}).get("content") or ""
+                    if delta:
+                        yield delta
+                    if obj.get("done"):
+                        break
+        return
+
+    # Non-streaming providers: one chunk, uniform interface.
+    result = await chat(
+        messages, provider=provider, temperature=temperature,
+        max_tokens=max_tokens, base_url=base_url, model=model,
+    )
+    text = ((result.get("choices") or [{}])[0].get("message", {}) or {}).get("content", "")
+    if text:
+        yield text

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -209,6 +209,14 @@ app.include_router(capabilities_router)
 # Compute status (Wave A / Batch 6): /compute/status, /compute/mode. Additive;
 # default mode is "local" so existing generation paths are unchanged.
 app.include_router(compute_router)
+# Compute admin (PR 2): /compute/admin/* — persisted sources, per-model routes,
+# manifests and settings. Additive; empty registry ⇒ legacy global-mode routing.
+from .compute.routes_admin import router as compute_admin_router  # noqa: E402
+app.include_router(compute_admin_router)
+# Compute streaming (P1): POST /v1/compute/chat/stream (SSE). Additive; the
+# existing non-streaming /chat is unchanged.
+from .compute.stream_routes import router as compute_stream_router  # noqa: E402
+app.include_router(compute_stream_router)
 
 # Include Agentic AI routes (/v1/agentic/*)
 app.include_router(agentic_router)

--- a/backend/app/orchestrator.py
+++ b/backend/app/orchestrator.py
@@ -10,7 +10,9 @@ import uuid
 from typing import Any, Dict, Optional, Literal
 
 from .comfy import check_nodes_available, run_workflow
-from .llm import chat as llm_chat, is_thinking_model, strip_think_tags, _is_reasoning_text, recover_from_reasoning
+from .llm import is_thinking_model, strip_think_tags, _is_reasoning_text, recover_from_reasoning
+from .compute import route_chat
+from .compute.router import build_diagnostics as _compute_diag
 from .prompts import BASE_SYSTEM, FUN_SYSTEM
 from .storage import add_message, get_recent
 from .config import DEFAULT_PROVIDER, ProviderName, LLM_MODEL, LLM_BASE_URL, OLLAMA_MODEL, OLLAMA_BASE_URL
@@ -590,7 +592,7 @@ async def _refine_prompt(
 
     try:
         print(f"[_refine_prompt] Sending to llm_chat...")
-        result = await llm_chat(
+        result = await route_chat(
             messages,
             provider=provider,
             temperature=0.7,
@@ -697,7 +699,7 @@ async def _refine_video_prompt(
 
     try:
         print(f"[_refine_video_prompt] Sending to llm_chat...")
-        result = await llm_chat(
+        result = await route_chat(
             messages,
             provider=provider,
             temperature=0.7,
@@ -2009,14 +2011,16 @@ async def orchestrate(
     )
     llm_started = time.perf_counter()
 
+    _route_report: dict = {}
     try:
-        out = await llm_chat(
+        out = await route_chat(
             messages,
             provider=prov,
             temperature=text_temperature if text_temperature is not None else (0.9 if fun_mode else 0.7),
             max_tokens=effective_max_tokens,
             base_url=provider_base_url,
             model=provider_model,
+            report=_route_report,
         )
     except Exception as e:
         llm_elapsed_ms = int((time.perf_counter() - llm_started) * 1000)
@@ -2111,7 +2115,12 @@ async def orchestrate(
     except Exception:
         pass
 
-    return {"conversation_id": cid, "text": text, "media": text_media}
+    return {
+        "conversation_id": cid,
+        "text": text,
+        "media": text_media,
+        "compute": _compute_diag(_route_report),
+    }
 
 
 async def handle_request(mode: Optional[str], payload: Dict[str, Any]) -> Dict[str, Any]:

--- a/backend/app/projects.py
+++ b/backend/app/projects.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List, Optional
 from pydantic import BaseModel, Field
 
 # Imports from your existing structure
-from .llm import chat as llm_chat
+from .compute import route_chat
 from .storage import add_message, get_recent
 from .tracing import log_event
 from .config import UPLOAD_DIR, PUBLIC_BASE_URL
@@ -1383,7 +1383,7 @@ You have access to the project's context. When relevant context from the knowled
             f"max_tokens={300 if is_voice else 900} is_persona={bool(is_persona)}"
         )
         _llm_started = _time.perf_counter()
-        response = await llm_chat(
+        response = await route_chat(
             messages,
             provider=provider,
             temperature=0.7,

--- a/backend/app/search.py
+++ b/backend/app/search.py
@@ -4,7 +4,7 @@ Implements web search with summarization (Grok-style) and conversation history s
 """
 from typing import Any, Dict, List, Optional
 import httpx
-from .llm import chat as llm_chat
+from .compute import route_chat
 from .storage import get_messages
 
 
@@ -55,7 +55,7 @@ async def summarize_results(query: str, results: List[Dict[str, Any]], provider:
     ]
 
     try:
-        response = await llm_chat(
+        response = await route_chat(
             messages,
             provider=provider,
             temperature=0.3,  # Lower temperature for factual summarization

--- a/backend/app/system_resources.py
+++ b/backend/app/system_resources.py
@@ -34,7 +34,39 @@ def _status_from_percent(
     return good_label
 
 
-def _get_gpu_info() -> Dict[str, Any]:
+def _parse_gpu_line(line: str) -> Dict[str, Any]:
+    parts = [p.strip() for p in line.split(",")]
+    name = parts[0]
+    total_mb = int(parts[1])
+    used_mb = int(parts[2])
+    free_mb = int(parts[3])
+    util = int(parts[4])
+    temp = int(parts[5])
+
+    free_ratio = free_mb / max(total_mb, 1)
+    if free_ratio < 0.15:
+        status = "tight"
+    elif free_ratio < 0.30:
+        status = "warning"
+    else:
+        status = "good"
+
+    return {
+        "available": True,
+        "name": name,
+        "vram_total_mb": total_mb,
+        "vram_used_mb": used_mb,
+        "vram_free_mb": free_mb,
+        "used_percent": round((used_mb / total_mb) * 100) if total_mb else 0,
+        "utilization_percent": util,
+        "temperature_c": temp,
+        "status": status,
+    }
+
+
+def _get_gpus_list() -> list:
+    """All local NVIDIA GPUs (not just the first). Fixes the single-GPU report
+    so the Resources UI can show a rig with multiple cards."""
     try:
         result = subprocess.run(
             [
@@ -44,47 +76,34 @@ def _get_gpu_info() -> Dict[str, Any]:
             ],
             capture_output=True, text=True, check=True, timeout=2.5,
         )
-        line = result.stdout.strip().splitlines()[0]
-        parts = [p.strip() for p in line.split(",")]
-
-        name = parts[0]
-        total_mb = int(parts[1])
-        used_mb = int(parts[2])
-        free_mb = int(parts[3])
-        util = int(parts[4])
-        temp = int(parts[5])
-
-        free_ratio = free_mb / max(total_mb, 1)
-        if free_ratio < 0.15:
-            status = "tight"
-        elif free_ratio < 0.30:
-            status = "warning"
-        else:
-            status = "good"
-
-        return {
-            "available": True,
-            "name": name,
-            "vram_total_mb": total_mb,
-            "vram_used_mb": used_mb,
-            "vram_free_mb": free_mb,
-            "used_percent": round((used_mb / total_mb) * 100) if total_mb else 0,
-            "utilization_percent": util,
-            "temperature_c": temp,
-            "status": status,
-        }
+        gpus = []
+        for i, line in enumerate(result.stdout.strip().splitlines()):
+            if not line.strip():
+                continue
+            g = _parse_gpu_line(line)
+            g["index"] = i
+            gpus.append(g)
+        return gpus
     except Exception:
-        return {
-            "available": False,
-            "name": None,
-            "vram_total_mb": None,
-            "vram_used_mb": None,
-            "vram_free_mb": None,
-            "used_percent": None,
-            "utilization_percent": None,
-            "temperature_c": None,
-            "status": "unavailable",
-        }
+        return []
+
+
+def _get_gpu_info() -> Dict[str, Any]:
+    """The primary GPU (back-compat single-GPU shape)."""
+    gpus = _get_gpus_list()
+    if gpus:
+        return gpus[0]
+    return {
+        "available": False,
+        "name": None,
+        "vram_total_mb": None,
+        "vram_used_mb": None,
+        "vram_free_mb": None,
+        "used_percent": None,
+        "utilization_percent": None,
+        "temperature_c": None,
+        "status": "unavailable",
+    }
 
 
 def _get_ram_info() -> Dict[str, Any]:
@@ -143,9 +162,10 @@ def _get_disk_info() -> Dict[str, Any]:
 
 @router.get("/resources")
 async def system_resources() -> JSONResponse:
-    """Machine capacity: GPU, RAM, CPU, disk."""
+    """Machine capacity: GPU(s), RAM, CPU, disk."""
     return JSONResponse({
-        "gpu": _get_gpu_info(),
+        "gpu": _get_gpu_info(),      # primary GPU (back-compat)
+        "gpus": _get_gpus_list(),    # all local GPUs (multi-GPU rigs)
         "ram": _get_ram_info(),
         "cpu": _get_cpu_info(),
         "disk": _get_disk_info(),

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -203,3 +203,25 @@ def mock_outbound(monkeypatch):
 
 
     return True
+
+
+@pytest.fixture()
+def compute_db(monkeypatch, tmp_path):
+    """Isolate the compute registry on a fresh temp SQLite DB and reset the
+    shared health cache, so registry/router tests don't leak state into each
+    other or into the session `app` fixture's DB."""
+    import app.storage as storage
+    prev_resolved = storage._RESOLVED_DB_PATH
+    prev_sqlite = storage.SQLITE_PATH
+    # storage binds SQLITE_PATH at import, so patch the module attr (not just env)
+    # and reset the resolved-path cache so _get_db_path() re-resolves to the temp DB.
+    monkeypatch.setattr(storage, "SQLITE_PATH", str(tmp_path / "compute.db"), raising=False)
+    storage._RESOLVED_DB_PATH = None
+    try:
+        from app.compute import health
+        health.shared_cache().invalidate()
+    except Exception:
+        pass
+    yield
+    storage._RESOLVED_DB_PATH = prev_resolved
+    storage.SQLITE_PATH = prev_sqlite

--- a/backend/tests/test_api_comprehensive.py
+++ b/backend/tests/test_api_comprehensive.py
@@ -72,7 +72,7 @@ def test_models_ollama_down(mock_client_class, client, mock_outbound):
     assert data["models"] == []
 
 
-@patch("app.orchestrator.llm_chat")
+@patch("app.orchestrator.route_chat")
 def test_chat_basic(mock_llm, client, mock_outbound):
     """Test /chat endpoint with mocked LLM."""
     # Mock LLM response
@@ -98,7 +98,7 @@ def test_chat_basic(mock_llm, client, mock_outbound):
     assert "Hello" in data["text"]
 
 
-@patch("app.orchestrator.llm_chat")
+@patch("app.orchestrator.route_chat")
 def test_chat_ollama_provider(mock_llm, client, mock_outbound):
     """Test /chat endpoint with Ollama provider."""
     mock_llm.return_value = {
@@ -125,7 +125,7 @@ def test_chat_ollama_provider(mock_llm, client, mock_outbound):
 
 
 @patch("app.orchestrator.run_workflow")
-@patch("app.orchestrator.llm_chat")
+@patch("app.orchestrator.route_chat")
 def test_chat_imagine_mode(mock_llm, mock_workflow, client, mock_outbound):
     """Test /chat endpoint in imagine mode."""
     # Mock prompt refiner
@@ -210,7 +210,7 @@ def test_cors_headers(client, mock_outbound):
     assert "access-control-allow-origin" in [h.lower() for h in r.headers.keys()]
 
 
-@patch("app.orchestrator.llm_chat")
+@patch("app.orchestrator.route_chat")
 def test_chat_error_handling(mock_llm, client, mock_outbound):
     """Test /chat endpoint handles errors gracefully."""
     # Mock LLM error

--- a/backend/tests/test_compute_admin_routes.py
+++ b/backend/tests/test_compute_admin_routes.py
@@ -1,0 +1,53 @@
+"""PR 2 — compute admin API (/compute/admin/*).
+
+Exercises the CRUD + resolve endpoints through the real FastAPI app. The test
+cleans up everything it creates so it doesn't perturb the shared session DB that
+other tests route against.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def test_compute_admin_crud_and_resolve(client):
+    # Create an OpenAI-compatible source with an inline credential (write-only).
+    r = client.post("/compute/admin/sources", json={
+        "id": "oa-test", "name": "OpenAI compat", "kind": "openai_compatible",
+        "base_url": "http://endpoint", "credential": "sk-secret",
+    })
+    assert r.status_code == 200, r.text
+    src = r.json()["source"]
+    assert src["credential_ref"]                 # a ref was minted
+    assert "credential" not in src               # secret never echoed back
+
+    # It appears in the list.
+    listed = client.get("/compute/admin/sources").json()["sources"]
+    assert any(s["id"] == "oa-test" for s in listed)
+
+    # Pin a model to that source with a local fallback.
+    r = client.post("/compute/admin/routes", json={
+        "modality": "chat", "model_id": "svc-model", "primary_target": "source:oa-test",
+        "fallback_targets": ["local"], "strategy": "pinned",
+    })
+    assert r.status_code == 200, r.text
+
+    # Resolve explains the plan.
+    plan = client.get("/compute/admin/resolve", params={
+        "modality": "chat", "model_id": "svc-model"}).json()
+    assert plan["matched"] == "route"
+    assert plan["targets"][0] == "source:oa-test"
+    assert "local" in plan["targets"]            # safe tail
+
+    # Missing required fields are rejected.
+    assert client.post("/compute/admin/routes", json={"modality": "chat"}).status_code == 400
+
+    # Cleanup so the shared DB is left as we found it.
+    assert client.delete("/compute/admin/routes/chat/svc-model").status_code == 200
+    assert client.delete("/compute/admin/sources/oa-test").status_code == 200
+    assert not any(
+        s["id"] == "oa-test" for s in client.get("/compute/admin/sources").json()["sources"]
+    )

--- a/backend/tests/test_compute_burst.py
+++ b/backend/tests/test_compute_burst.py
@@ -14,7 +14,7 @@ import pytest
 
 
 class _FakeCloud:
-    async def available(self) -> bool:
+    async def available(self, modality=None) -> bool:
         return True
 
 
@@ -33,7 +33,7 @@ def env(monkeypatch):
     monkeypatch.setattr(config, "OLLABRIDGE_CLOUD_URL", "https://cloud.example", raising=False)
     monkeypatch.setattr(config, "OLLABRIDGE_CLOUD_TOKEN", "tok", raising=False)
 
-    async def _local_off(self):
+    async def _local_off(self, modality=None):
         return False
 
     monkeypatch.setattr(compute.LocalComputeProvider, "available", _local_off, raising=False)

--- a/backend/tests/test_compute_cost.py
+++ b/backend/tests/test_compute_cost.py
@@ -1,0 +1,96 @@
+"""PR 5 — cost-aware routing: estimates, budgets, and route explanations."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+# ---- estimates ----------------------------------------------------------
+
+def test_own_hardware_is_free_by_default(compute_db):
+    from app.compute import cost, registry
+    s = registry.load_settings()
+    for t in ("local", "ollabridge_cloud", "device:colab", "source:my-vllm"):
+        est = cost.estimate_target(t, "chat", s)
+        assert est.estimated_usd == 0.0 and est.known
+
+    # A free hosted alias is free; an unpriced hosted provider is unknown.
+    assert cost.estimate_target("provider:free-best", "chat", s).estimated_usd == 0.0
+    assert cost.estimate_target("provider:groq", "chat", s).known is False
+
+
+def test_catalog_override_wins(compute_db):
+    from app.compute import cost, registry
+    s = registry.load_settings()
+    s.cost_catalog = {"provider:groq": {"usd": 0.02, "per_unit": "request", "as_of": "2026-08-01", "note": "list"}}
+    registry.save_settings(s)
+    est = cost.estimate_target("provider:groq", "chat", registry.load_settings())
+    assert est.estimated_usd == 0.02 and est.as_of == "2026-08-01" and est.per_unit == "request"
+
+
+def test_within_budget_semantics():
+    from app.compute import cost
+    from app.compute.cost import CostEstimate
+    assert cost.within_budget(CostEstimate("x", estimated_usd=None), 1.0) is True   # unknown allowed
+    assert cost.within_budget(CostEstimate("x", estimated_usd=0.5), 1.0) is True
+    assert cost.within_budget(CostEstimate("x", estimated_usd=2.0), 1.0) is False
+    assert cost.within_budget(CostEstimate("x", estimated_usd=2.0), None) is True    # no budget
+
+
+# ---- budget filtering in resolution -------------------------------------
+
+def test_route_budget_drops_expensive_device(compute_db):
+    from app.compute import registry, policies
+    from app.compute.schemas import ModelRoute
+    s = registry.load_settings()
+    s.cost_catalog = {"device:colab": {"usd": 2.0}}
+    registry.save_settings(s)
+    registry.upsert_route(ModelRoute(
+        modality="chat", model_id="m", primary_target="device:colab",
+        fallback_targets=["local"], strategy="pinned", max_cost_usd=1.0,
+    ))
+    targets = policies.resolve_targets("chat", "m")
+    assert "device:colab" not in targets   # 2.0 > 1.0 budget
+    assert "local" in targets              # free fallback survives
+
+
+def test_global_budget_applies_without_route(compute_db):
+    from app.compute import registry, policies
+    from app.compute.schemas import ModalityDefault
+    s = registry.load_settings()
+    s.max_cost_usd_per_request = 1.0
+    s.cost_catalog = {"device:rig": {"usd": 5.0}}
+    s.modality_defaults["chat"] = ModalityDefault(
+        modality="chat", strategy="pinned", target="device:rig",
+        fallback_targets=["local"], privacy="private_nodes")
+    registry.save_settings(s)
+    targets = policies.resolve_targets("chat", "any-model")
+    assert "device:rig" not in targets and "local" in targets
+
+
+# ---- explanations -------------------------------------------------------
+
+def test_explain_reports_costs_and_budget(compute_db):
+    from app.compute import registry, policies
+    from app.compute.schemas import ModelRoute
+    s = registry.load_settings()
+    s.cost_catalog = {"provider:groq": {"usd": 5.0}}
+    registry.save_settings(s)
+    registry.upsert_route(ModelRoute(
+        modality="chat", model_id="m", primary_target="provider:groq",
+        fallback_targets=["local"], strategy="pinned",
+        privacy="hosted_allowed", max_cost_usd=1.0,
+    ))
+    ex = policies.explain("chat", "m")
+    assert ex["budget_usd"] == 1.0
+    by_target = {c["target"]: c for c in ex["costs"]}
+    # The expensive hosted option is shown, priced, and flagged over budget.
+    assert by_target["provider:groq"]["estimated_usd"] == 5.0
+    assert by_target["provider:groq"]["over_budget"] is True
+    assert by_target["provider:groq"]["selected"] is False
+    # Local is free, selected, within budget.
+    assert by_target["local"]["estimated_usd"] == 0.0
+    assert by_target["local"]["selected"] is True

--- a/backend/tests/test_compute_netguard.py
+++ b/backend/tests/test_compute_netguard.py
@@ -1,0 +1,65 @@
+"""Security — SSRF guard for custom compute endpoints."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+
+
+def test_netguard_allows_legit_and_blocks_dangerous():
+    from app.compute.netguard import is_safe_outbound_url as safe
+    # Legit: hosted APIs, and self-hosted loopback/LAN GPU nodes.
+    assert safe("https://api.groq.com/openai/v1")
+    assert safe("http://localhost:11434")
+    assert safe("http://192.168.1.50:8000")
+    assert safe("http://10.0.0.4:8188")
+    assert safe(None)  # nothing to dial
+    # Dangerous: cloud metadata, link-local, non-http schemes, no host.
+    assert not safe("http://169.254.169.254/latest/meta-data/")
+    assert not safe("http://metadata.google.internal/")
+    assert not safe("http://[fe80::1]/")
+    assert not safe("file:///etc/passwd")
+    assert not safe("ftp://host/x")
+    assert not safe("http://")
+
+
+def test_block_private_env_tightens_policy(monkeypatch):
+    from app.compute import netguard
+    monkeypatch.setenv("HOMEPILOT_COMPUTE_BLOCK_PRIVATE", "true")
+    # With the strict flag, private/loopback are refused too.
+    assert netguard.is_safe_outbound_url("http://10.0.0.4:8000") is False
+    assert netguard.is_safe_outbound_url("http://localhost:11434") is False
+    # Public still fine.
+    assert netguard.is_safe_outbound_url("https://api.groq.com") is True
+
+
+def test_admin_source_create_rejects_metadata_url(client):
+    r = client.post("/compute/admin/sources", json={
+        "id": "evil", "name": "evil", "kind": "openai_compatible",
+        "base_url": "http://169.254.169.254/latest/meta-data/",
+    })
+    assert r.status_code == 400
+    assert "metadata" in r.text.lower() or "blocked" in r.text.lower()
+    # It was not persisted.
+    listed = client.get("/compute/admin/sources").json()["sources"]
+    assert not any(s["id"] == "evil" for s in listed)
+
+
+def test_admin_source_test_refuses_blocked_url(client):
+    # A source that somehow holds a blocked URL is not dialed.
+    client.post("/compute/admin/sources", json={
+        "id": "vllm-ok", "name": "vLLM", "kind": "openai_compatible",
+        "base_url": "http://10.0.0.9:8000",
+    })
+    # Re-point it to a blocked URL directly via the registry, then test().
+    from app.compute import registry
+    src = registry.get_source("vllm-ok")
+    src.base_url = "http://169.254.169.254"
+    registry.upsert_source(src)
+    r = client.post("/compute/admin/sources/vllm-ok/test").json()
+    assert r["ok"] is False and ("blocked" in r["reason"].lower() or "metadata" in r["reason"].lower())
+    client.delete("/compute/admin/sources/vllm-ok")

--- a/backend/tests/test_compute_readiness.py
+++ b/backend/tests/test_compute_readiness.py
@@ -1,0 +1,56 @@
+"""Production-readiness signal for Compute Sources & Routing."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def test_unconfigured_reports_not_ready_with_actionable_warnings(monkeypatch):
+    from app.compute import readiness
+    for k in ("HOMEPILOT_COMPUTE_SECRET_KEY", "HOMEPILOT_CLOUD_TOKEN_KEY"):
+        monkeypatch.delenv(k, raising=False)
+    monkeypatch.setattr("app.config.API_KEY", "", raising=False)
+
+    r = readiness.production_readiness()
+    assert r["production_ready"] is False
+    assert r["checks"]["ssrf_guard"] is True
+    assert r["multi_tenant_registry"] is False
+    joined = " ".join(r["warnings"]).lower()
+    assert "homepilot_compute_secret_key" in joined
+    assert "api_key" in joined
+
+
+def test_fully_configured_reports_ready(monkeypatch):
+    from app.compute import readiness
+    monkeypatch.setattr(readiness, "_crypto_available", lambda: True)
+    monkeypatch.setenv("HOMEPILOT_COMPUTE_SECRET_KEY", "k1")
+    monkeypatch.setenv("HOMEPILOT_CLOUD_TOKEN_KEY", "k2")
+    monkeypatch.setattr("app.config.API_KEY", "secret", raising=False)
+    monkeypatch.setattr("app.config.OLLABRIDGE_CLOUD_URL", "https://app.ollabridge.com", raising=False)
+
+    r = readiness.production_readiness()
+    assert r["production_ready"] is True
+    assert all(r["checks"][k] for k in ("source_secrets_encrypted", "cloud_token_encrypted", "external_api_key_set"))
+    assert r["warnings"] == []
+
+
+def test_non_canonical_cloud_url_is_advisory_only(monkeypatch):
+    from app.compute import readiness
+    monkeypatch.setattr(readiness, "_crypto_available", lambda: True)
+    monkeypatch.setenv("HOMEPILOT_COMPUTE_SECRET_KEY", "k1")
+    monkeypatch.setenv("HOMEPILOT_CLOUD_TOKEN_KEY", "k2")
+    monkeypatch.setattr("app.config.API_KEY", "secret", raising=False)
+    monkeypatch.setattr("app.config.OLLABRIDGE_CLOUD_URL", "https://ruslanmv-ollabridge.hf.space", raising=False)
+
+    r = readiness.production_readiness()
+    # Still "ready" (advisory), but a warning nudges toward the canonical URL.
+    assert r["production_ready"] is True
+    assert any("canonical" in w.lower() for w in r["warnings"])
+
+
+def test_readiness_endpoint(client):
+    body = client.get("/compute/readiness").json()
+    assert "production_ready" in body and "checks" in body and "warnings" in body

--- a/backend/tests/test_compute_registry.py
+++ b/backend/tests/test_compute_registry.py
@@ -1,0 +1,186 @@
+"""PR 2 — registry, secrets, health cache, policies, provider factory.
+
+Covers the persisted registry (sources/devices/manifests/routes/settings), the
+credential store, the circuit-breaking health cache, route resolution order and
+static filtering, and the target→provider factory.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+
+
+# ---- schemas round-trip -------------------------------------------------
+
+def test_schema_round_trip():
+    from app.compute.schemas import ComputeSource, ModelRoute, ModelManifest
+
+    src = ComputeSource(id="s", name="S", kind="openai_compatible", base_url="http://x")
+    assert ComputeSource.from_dict(src.to_dict()) == src
+
+    route = ModelRoute(modality="chat", model_id="m", primary_target="device:d",
+                       fallback_targets=["local"], strategy="prefer_local")
+    assert ModelRoute.from_dict(route.to_dict()) == route
+
+    man = ModelManifest(id="m", runtime="ollama", capabilities=["chat", "vision"],
+                        device_ids=["d"], minimum_vram_mb=8000)
+    assert ModelManifest.from_dict(man.to_dict()).supports("vision")
+
+
+# ---- registry + settings ------------------------------------------------
+
+def test_registry_crud_and_settings_overlay(compute_db):
+    from app.compute import registry
+    from app.compute.schemas import ComputeSource, ModelRoute, ComputeSettings
+
+    assert registry.is_empty() is True
+
+    registry.upsert_source(ComputeSource(id="oa", name="OpenAI", kind="openai_compatible"))
+    assert registry.get_source("oa").kind == "openai_compatible"
+    assert registry.is_empty() is False
+
+    registry.upsert_route(ModelRoute(modality="chat", model_id="m", primary_target="local"))
+    assert registry.get_route("m", "chat").primary_target == "local"
+    registry.delete_route("m", "chat")
+    assert registry.get_route("m", "chat") is None
+
+    # Settings overlay: env default first, persisted override wins.
+    base = registry.load_settings()
+    assert base.compute_mode in ("local", "ollabridge_cloud", "auto")
+    base.compute_mode = "auto"
+    registry.save_settings(base)
+    assert registry.load_settings().compute_mode == "auto"
+
+
+def test_secrets_store_never_returns_missing(compute_db):
+    from app.compute import secrets
+    ref = secrets.put_secret("sk-123")
+    assert secrets.get_secret(ref) == "sk-123"
+    secrets.delete_secret(ref)
+    assert secrets.get_secret(ref) is None
+    assert secrets.get_secret(None) is None
+
+
+# ---- health cache / circuit breaker -------------------------------------
+
+async def test_health_cache_caches_within_ttl():
+    from app.compute.health import HealthCache
+    t = {"n": 100.0}
+    cache = HealthCache(ttl_s=10, clock=lambda: t["n"])
+    calls = {"n": 0}
+
+    async def probe():
+        calls["n"] += 1
+        return True
+
+    assert await cache.healthy("k", probe) is True
+    assert await cache.healthy("k", probe) is True  # cached — no second probe
+    assert calls["n"] == 1
+    t["n"] += 20  # TTL expired
+    assert await cache.healthy("k", probe) is True
+    assert calls["n"] == 2
+
+
+async def test_circuit_breaker_opens_after_failures():
+    from app.compute.health import HealthCache
+    t = {"n": 0.0}
+    cache = HealthCache(ttl_s=1, fail_threshold=3, cooldown_s=30, clock=lambda: t["n"])
+
+    async def bad():
+        return False
+
+    for _ in range(3):
+        t["n"] += 2  # step past ttl each time so the probe actually runs
+        await cache.healthy("k", bad)
+    # 3 consecutive failures → breaker open → allows() is False without probing.
+    assert cache.allows("k") is False
+    t["n"] += 40  # past cooldown
+    assert cache.allows("k") is True
+
+
+# ---- policies (resolution order + filters) ------------------------------
+
+def test_policy_resolution_order(compute_db):
+    from app.compute import registry, policies
+    from app.compute.schemas import ModelRoute, ComputeSettings, ModalityDefault
+
+    # Global default (no route, no modality default) → compute_mode targets.
+    s = registry.load_settings(); s.compute_mode = "local"; registry.save_settings(s)
+    assert policies.resolve_targets("chat", "x") == ["local"]
+
+    # Modality default beats global.
+    s = registry.load_settings()
+    s.modality_defaults["chat"] = ModalityDefault(
+        modality="chat", strategy="pinned", target="ollabridge_cloud", fallback_targets=["local"])
+    registry.save_settings(s)
+    assert policies.resolve_targets("chat", "x")[0] == "ollabridge_cloud"
+
+    # Explicit per-model route beats the modality default.
+    registry.upsert_route(ModelRoute(
+        modality="chat", model_id="deepseek", primary_target="device:colab",
+        fallback_targets=["local"], strategy="pinned"))
+    assert policies.resolve_targets("chat", "deepseek")[0] == "device:colab"
+
+
+def test_policy_prefer_local_reorders(compute_db):
+    from app.compute import registry, policies
+    from app.compute.schemas import ModelRoute
+    registry.upsert_route(ModelRoute(
+        modality="image", model_id="m", primary_target="device:remote",
+        fallback_targets=["local"], strategy="prefer_local"))
+    # prefer_local pulls local to the front regardless of author order.
+    assert policies.resolve_targets("image", "m")[0] == "local"
+
+
+def test_policy_privacy_local_only_drops_remote(compute_db):
+    from app.compute import registry, policies
+    from app.compute.schemas import ModelRoute
+    registry.upsert_route(ModelRoute(
+        modality="chat", model_id="m", primary_target="ollabridge_cloud",
+        fallback_targets=["local"], strategy="pinned", privacy="local_only"))
+    assert policies.resolve_targets("chat", "m") == ["local"]
+
+
+def test_policy_capability_filter_drops_unqualified_device(compute_db):
+    from app.compute import registry, policies
+    from app.compute.schemas import ModelRoute, ModelManifest, ComputeDevice
+    # Device advertises only 8GB; model needs 20GB → device dropped, local tail kept.
+    registry.upsert_device(ComputeDevice(id="colab", source_id="ob", vram_mb=8000, online=True))
+    registry.upsert_manifest(ModelManifest(
+        id="big", runtime="comfyui", capabilities=["image"],
+        device_ids=["colab"], minimum_vram_mb=20000))
+    registry.upsert_route(ModelRoute(
+        modality="image", model_id="big", primary_target="device:colab",
+        fallback_targets=["local"], strategy="pinned"))
+    assert "device:colab" not in policies.resolve_targets("image", "big")
+
+
+# ---- provider factory ---------------------------------------------------
+
+def test_build_target_local_and_openai(compute_db):
+    from app.compute import registry, secrets, providers
+    from app.compute.schemas import ComputeSource
+
+    built = providers.build_target("local")
+    assert built and built.provider.name == "local" and built.remote is False
+
+    ref = secrets.put_secret("sk-xyz")
+    registry.upsert_source(ComputeSource(
+        id="oa", name="OpenAI compat", kind="openai_compatible",
+        base_url="http://endpoint", credential_ref=ref))
+    b2 = providers.build_target("source:oa")
+    assert b2 and b2.provider.name == "openai_compatible" and b2.remote is True
+    assert b2.provider.api_key == "sk-xyz"
+
+    # Device target carries routing metadata for the Cloud relay.
+    s = registry.load_settings(); s.cloud_url = "https://cloud.test"; registry.save_settings(s)
+    b3 = providers.build_target("device:colab")
+    assert b3 and b3.extra["routing"]["device_id"] == "colab"
+
+    # Unknown / disabled → None (router skips it).
+    assert providers.build_target("provider:free-best") is None

--- a/backend/tests/test_compute_router.py
+++ b/backend/tests/test_compute_router.py
@@ -1,0 +1,213 @@
+"""PR 1 foundation — modality-specific health + ComputeRouter seam.
+
+Proves the two behaviours this PR adds:
+
+  * Local health is per-modality: chat asks Ollama, image asks ComfyUI, so a
+    healthy Ollama is *available for chat* even when ComfyUI is down (and the
+    reverse). This is the fix for the "local health is ComfyUI-only" bug.
+  * ComputeRouter is a behaviour-preserving seam: in local mode it delegates to
+    llm.chat with identical arguments, and it only falls back off a *remote*
+    provider (pre-output, non-streaming) to a healthy local runtime.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+
+
+# ---- modality-specific local health -------------------------------------
+
+async def test_local_chat_health_uses_ollama_not_comfyui(monkeypatch):
+    from app.compute import local as local_mod
+
+    # Ollama up, ComfyUI down.
+    monkeypatch.setattr(local_mod, "_comfy_healthy", lambda: False)
+    async def _ollama_up():
+        return True
+    monkeypatch.setattr(local_mod, "_ollama_healthy", _ollama_up)
+
+    provider = local_mod.LocalComputeProvider()
+    assert await provider.available("chat") is True      # chat → Ollama (up)
+    assert await provider.available("image") is False     # image → ComfyUI (down)
+
+
+async def test_local_image_health_uses_comfyui_not_ollama(monkeypatch):
+    from app.compute import local as local_mod
+
+    # ComfyUI up, Ollama down.
+    monkeypatch.setattr(local_mod, "_comfy_healthy", lambda: True)
+    async def _ollama_down():
+        return False
+    monkeypatch.setattr(local_mod, "_ollama_healthy", _ollama_down)
+
+    provider = local_mod.LocalComputeProvider()
+    assert await provider.available("image") is True      # image → ComfyUI (up)
+    assert await provider.available("chat") is False       # chat → Ollama (down)
+    assert await provider.available(None) is True          # any runtime up
+
+
+async def test_auto_mode_resolves_local_for_chat_when_only_ollama_up(monkeypatch):
+    from app.compute import local as local_mod
+
+    monkeypatch.setattr("app.config.HOMEPILOT_COMPUTE_MODE", "auto", raising=False)
+    monkeypatch.setattr(local_mod, "_comfy_healthy", lambda: False)  # ComfyUI down
+    async def _ollama_up():
+        return True
+    monkeypatch.setattr(local_mod, "_ollama_healthy", _ollama_up)    # Ollama up
+
+    from app.compute import resolve_mode
+    assert await resolve_mode("chat") == "local"
+
+
+# ---- ComputeRouter seam -------------------------------------------------
+
+async def test_route_chat_local_delegates_with_identical_args(compute_db, monkeypatch):
+    monkeypatch.setattr("app.config.HOMEPILOT_COMPUTE_MODE", "local", raising=False)
+
+    captured: dict = {}
+
+    async def fake_chat(messages, **kwargs):
+        captured["messages"] = messages
+        captured["kwargs"] = kwargs
+        return {"choices": [{"message": {"content": "ok"}}]}
+
+    monkeypatch.setattr("app.llm.chat", fake_chat, raising=False)
+
+    from app.compute import route_chat
+    msgs = [{"role": "user", "content": "hi"}]
+    out = await route_chat(
+        msgs, provider="ollama", model="llama3.2:3b",
+        base_url="http://x", temperature=0.3, max_tokens=150,
+    )
+    assert out["choices"][0]["message"]["content"] == "ok"
+    assert captured["messages"] is msgs
+    # Local delegation forwards exactly what llm.chat expects — nothing dropped.
+    assert captured["kwargs"] == {
+        "model": "llama3.2:3b", "provider": "ollama",
+        "base_url": "http://x", "temperature": 0.3, "max_tokens": 150,
+    }
+
+
+class _FakeCloud:
+    """Stands in for the Cloud relay; its chat always fails (unreachable)."""
+    name = "ollabridge_cloud"
+    async def chat(self, **_):
+        raise ConnectionError("cloud unreachable")
+
+
+async def test_router_falls_back_from_remote_to_local(compute_db, monkeypatch):
+    from app.compute import registry
+    from app.compute.router import ComputeRouter
+    from app.compute.schemas import ModelRoute
+
+    # Pin the model to the Cloud relay, with local as the explicit fallback.
+    monkeypatch.setattr("app.compute.providers._build_cloud", lambda settings: _FakeCloud())
+    registry.upsert_route(ModelRoute(
+        modality="chat", model_id="m", primary_target="ollabridge_cloud",
+        fallback_targets=["local"], strategy="pinned",
+    ))
+
+    async def fake_chat(messages, **kwargs):
+        return {"choices": [{"message": {"content": "served-locally"}}]}
+    monkeypatch.setattr("app.llm.chat", fake_chat, raising=False)
+
+    out = await ComputeRouter().chat([{"role": "user", "content": "hi"}], model="m")
+    # Cloud failed pre-output, so the request fell through to the local runtime.
+    assert out["choices"][0]["message"]["content"] == "served-locally"
+
+
+async def test_route_report_records_local_winner(compute_db, monkeypatch):
+    monkeypatch.setattr("app.config.HOMEPILOT_COMPUTE_MODE", "local", raising=False)
+
+    async def fake_chat(messages, **kwargs):
+        return {"choices": [{"message": {"content": "ok"}}]}
+    monkeypatch.setattr("app.llm.chat", fake_chat, raising=False)
+
+    from app.compute import route_chat
+    from app.compute.router import build_diagnostics
+    report: dict = {}
+    await route_chat([{"role": "user", "content": "hi"}], model="m", report=report)
+    diag = build_diagnostics(report)
+    assert diag["target"] == "local" and diag["label"] == "This PC"
+    assert diag["fell_back"] is False
+
+
+async def test_route_report_records_fallback_and_device_label(compute_db, monkeypatch):
+    from app.compute import registry
+    from app.compute.router import ComputeRouter, build_diagnostics, describe_target
+    from app.compute.schemas import ModelRoute, ComputeDevice
+
+    # Name the device so diagnostics can label it, and pin the model to it.
+    registry.upsert_device(ComputeDevice(id="colab", source_id="ollabridge-cloud", name="Colab T4", online=True))
+    registry.upsert_route(ModelRoute(
+        modality="chat", model_id="m", primary_target="device:colab",
+        fallback_targets=["local"], strategy="pinned",
+    ))
+    monkeypatch.setattr("app.compute.providers._build_cloud", lambda settings: _FakeCloud())
+
+    async def fake_chat(messages, **kwargs):
+        return {"choices": [{"message": {"content": "served-locally"}}]}
+    monkeypatch.setattr("app.llm.chat", fake_chat, raising=False)
+
+    assert describe_target("device:colab") == "Colab T4"
+
+    report: dict = {}
+    await ComputeRouter().chat([{"role": "user", "content": "hi"}], model="m", report=report)
+    diag = build_diagnostics(report)
+    # Cloud failed → fell back to local; the report explains why.
+    assert diag["target"] == "local" and diag["fell_back"] is True
+    assert diag["reason"]  # carries the cloud failure reason
+
+
+async def test_offline_device_reason_names_heartbeat_age(compute_db, monkeypatch):
+    import time as _t
+    from app.compute import registry
+    from app.compute.router import ComputeRouter, build_diagnostics
+    from app.compute.schemas import ModelRoute, ComputeDevice
+
+    # A device Cloud last reported offline 22s ago.
+    registry.upsert_device(ComputeDevice(
+        id="colab", source_id="ollabridge-cloud", name="Colab T4",
+        online=False, last_heartbeat=_t.time() - 22,
+    ))
+    registry.upsert_route(ModelRoute(
+        modality="chat", model_id="m", primary_target="device:colab",
+        fallback_targets=["local"], strategy="pinned",
+    ))
+
+    async def fake_chat(messages, **kwargs):
+        return {"choices": [{"message": {"content": "local"}}]}
+    monkeypatch.setattr("app.llm.chat", fake_chat, raising=False)
+
+    report: dict = {}
+    await ComputeRouter().chat([{"role": "user", "content": "hi"}], model="m", report=report)
+    diag = build_diagnostics(report)
+    assert diag["target"] == "local" and diag["fell_back"] is True
+    # The premium, actionable reason — device name + heartbeat age.
+    assert "Colab T4 offline" in diag["reason"]
+    assert "heartbeat expired" in diag["reason"]
+
+
+async def test_router_reraises_when_all_targets_fail(compute_db, monkeypatch):
+    from app.compute import registry
+    from app.compute.router import ComputeRouter
+    from app.compute.schemas import ModelRoute
+
+    monkeypatch.setattr("app.compute.providers._build_cloud", lambda settings: _FakeCloud())
+    registry.upsert_route(ModelRoute(
+        modality="chat", model_id="m", primary_target="ollabridge_cloud",
+        fallback_targets=[], strategy="pinned",
+    ))
+
+    async def failing_chat(messages, **kwargs):
+        raise ConnectionError("local down too")
+    monkeypatch.setattr("app.llm.chat", failing_chat, raising=False)
+
+    # Cloud fails, and the safe local tail fails too → the error propagates.
+    with pytest.raises(ConnectionError):
+        await ComputeRouter().chat([{"role": "user", "content": "hi"}], model="m")

--- a/backend/tests/test_compute_stream.py
+++ b/backend/tests/test_compute_stream.py
@@ -1,0 +1,112 @@
+"""P1 — token streaming: provider/router streaming + safe-streaming fallback."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+
+
+async def _collect(agen):
+    out = []
+    async for x in agen:
+        out.append(x)
+    return out
+
+
+# ---- OpenAI SSE parser ----------------------------------------------------
+
+async def test_iter_openai_sse_parses_deltas():
+    from app.compute.base import iter_openai_sse
+
+    class FakeResp:
+        async def aiter_lines(self):
+            for l in [
+                'data: {"choices":[{"delta":{"content":"Hel"}}]}',
+                "",  # keep-alive blank
+                'data: {"choices":[{"delta":{"content":"lo"}}]}',
+                "data: [DONE]",
+                'data: {"choices":[{"delta":{"content":"ignored"}}]}',
+            ]:
+                yield l
+
+    assert await _collect(iter_openai_sse(FakeResp())) == ["Hel", "lo"]
+
+
+# ---- local streaming via llm.stream_chat ----------------------------------
+
+async def test_route_chat_stream_local(compute_db, monkeypatch):
+    monkeypatch.setattr("app.config.HOMEPILOT_COMPUTE_MODE", "local", raising=False)
+
+    async def fake_stream(messages, **kwargs):
+        for tok in ["Hello", ", ", "world"]:
+            yield tok
+    monkeypatch.setattr("app.llm.stream_chat", fake_stream, raising=False)
+
+    from app.compute.router import route_chat_stream, build_diagnostics
+    report: dict = {}
+    deltas = await _collect(route_chat_stream(
+        [{"role": "user", "content": "hi"}], model="m", report=report))
+    assert "".join(deltas) == "Hello, world"
+    assert build_diagnostics(report)["target"] == "local"
+
+
+# ---- safe-streaming fallback (before first token only) --------------------
+
+class _CloudFailsBeforeToken:
+    name = "ollabridge_cloud"
+    async def chat_stream(self, **_):
+        raise ConnectionError("cloud unreachable")
+        yield  # pragma: no cover — makes this an async generator
+
+
+class _CloudFailsMidStream:
+    name = "ollabridge_cloud"
+    async def chat_stream(self, **_):
+        yield "partial "
+        raise ConnectionError("dropped mid-stream")
+
+
+def _pin_cloud(monkeypatch, cloud_obj):
+    from app.compute import registry
+    from app.compute.schemas import ModelRoute
+    monkeypatch.setattr("app.compute.providers._build_cloud", lambda settings: cloud_obj)
+    registry.upsert_route(ModelRoute(
+        modality="chat", model_id="m", primary_target="ollabridge_cloud",
+        fallback_targets=["local"], strategy="pinned"))
+
+
+async def test_stream_falls_back_before_first_token(compute_db, monkeypatch):
+    _pin_cloud(monkeypatch, _CloudFailsBeforeToken())
+
+    async def fake_stream(messages, **kwargs):
+        yield "served locally"
+    monkeypatch.setattr("app.llm.stream_chat", fake_stream, raising=False)
+
+    from app.compute.router import ComputeRouter, build_diagnostics
+    report: dict = {}
+    deltas = await _collect(ComputeRouter().chat_stream(
+        [{"role": "user", "content": "hi"}], model="m", report=report))
+    assert "".join(deltas) == "served locally"
+    diag = build_diagnostics(report)
+    assert diag["target"] == "local" and diag["fell_back"] is True and diag["reason"]
+
+
+async def test_stream_never_restarts_after_first_token(compute_db, monkeypatch):
+    _pin_cloud(monkeypatch, _CloudFailsMidStream())
+
+    async def fake_stream(messages, **kwargs):
+        yield "SHOULD-NOT-APPEAR"
+    monkeypatch.setattr("app.llm.stream_chat", fake_stream, raising=False)
+
+    from app.compute.router import ComputeRouter
+    got = []
+    with pytest.raises(ConnectionError):
+        async for d in ComputeRouter().chat_stream(
+            [{"role": "user", "content": "hi"}], model="m"):
+            got.append(d)
+    # The partial cloud token reached the caller; we did NOT restart on local.
+    assert got == ["partial "]

--- a/backend/tests/test_compute_sync.py
+++ b/backend/tests/test_compute_sync.py
@@ -1,0 +1,100 @@
+"""P0-1 — Cloud → registry sync: mapping, manifest-driven caps, reconcile."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+
+
+def test_map_device_defensive_shapes():
+    from app.compute.sync import map_device, CLOUD_SOURCE_ID
+    d = map_device(
+        {"id": "colab", "name": "Colab T4", "online": True, "ephemeral": True,
+         "gpu": {"name": "NVIDIA T4", "vram_mb": 15360}, "capacity": 1, "active_jobs": 0,
+         "last_seen": "2026-08-03T09:35:00Z"},
+        now=1_800_000_000.0,
+    )
+    assert d.source_id == CLOUD_SOURCE_ID
+    assert d.gpu_name == "NVIDIA T4" and d.vram_mb == 15360
+    assert d.online and d.ephemeral and d.last_heartbeat is not None
+
+    # Flat gpu fields + offline (no heartbeat stamped when offline).
+    d2 = map_device({"id": "rig", "gpu_name": "RTX 4090", "vram_mb": 24576, "online": False})
+    assert d2.gpu_name == "RTX 4090" and d2.vram_mb == 24576
+    assert d2.online is False and d2.last_heartbeat is None
+
+
+def test_map_manifests_are_capability_driven_not_name_guessed():
+    from app.compute.sync import map_manifests
+    payload = {"data": [
+        {"id": "llama3.2:3b", "x_source": "shared_device", "owned_by": "relay:colab"},
+        {"id": "moondream", "x_source": "shared_device", "device_id": "colab",
+         "capabilities": ["chat", "vision"]},
+        {"id": "route-alias", "x_source": "route"},  # not node inventory → skipped
+    ]}
+    device_caps = {"colab": ["chat"]}
+    mans = {m.id: m for m in map_manifests(payload, device_caps)}
+    assert set(mans) == {"llama3.2:3b", "moondream"}
+    assert mans["llama3.2:3b"].capabilities == ["chat"]
+    # moondream advertises vision → multimodal, from the manifest, not its name.
+    assert "multimodal" in mans["moondream"].capabilities
+    assert mans["moondream"].device_ids == ["colab"]
+
+
+async def _run_sync(compute_devices, models_payload):
+    from app.compute import sync
+
+    async def fetch(path):
+        if path == "/v1/devices":
+            return 200, compute_devices
+        if path == "/ollama/v1/models":
+            return 200, models_payload
+        return 404, None
+
+    return await sync.sync_from_cloud("https://app.ollabridge.com", fetch=fetch)
+
+
+async def test_sync_populates_registry(compute_db):
+    from app.compute import registry, sync
+    res = await _run_sync(
+        [{"id": "colab", "name": "Colab T4", "online": True, "ephemeral": True,
+          "gpu": {"name": "NVIDIA T4", "vram_mb": 15360}, "capabilities": ["chat"]}],
+        {"data": [{"id": "llama3.2:3b", "x_source": "shared_device", "device_id": "colab"}]},
+    )
+    assert res == {"ok": True, "linked": True, "devices": 1, "models": 1,
+                   "source_id": sync.CLOUD_SOURCE_ID}
+    # The managed Cloud source + device + manifest are now in the registry.
+    assert registry.get_source(sync.CLOUD_SOURCE_ID).kind == "ollabridge"
+    dev = registry.get_device("colab")
+    assert dev and dev.is_online() and dev.name == "Colab T4"
+    man = registry.get_manifest("llama3.2:3b")
+    assert man and "colab" in man.device_ids
+
+
+async def test_sync_marks_missing_devices_offline(compute_db):
+    from app.compute import registry
+    # First sync: two online devices.
+    await _run_sync(
+        [{"id": "a", "online": True}, {"id": "b", "online": True}],
+        {"data": []},
+    )
+    assert registry.get_device("a").online and registry.get_device("b").online
+    # Second sync only reports "a" → "b" is reconciled offline, not deleted.
+    await _run_sync([{"id": "a", "online": True}], {"data": []})
+    assert registry.get_device("a").online is True
+    b = registry.get_device("b")
+    assert b is not None and b.online is False
+
+
+async def test_sync_unlinked_when_cloud_401(compute_db):
+    from app.compute import sync
+
+    async def fetch(path):
+        return 401, {"error": "unauthorized"}
+
+    res = await sync.sync_from_cloud("https://app.ollabridge.com", fetch=fetch)
+    assert res["ok"] is False and res["linked"] is False and res["devices"] == 0

--- a/docs/COMPUTE_PRODUCTION.md
+++ b/docs/COMPUTE_PRODUCTION.md
@@ -1,0 +1,215 @@
+# Connect a GPU to HomePilot — step by step
+
+**Goal:** run HomePilot on your own computer, but do the heavy AI work on a
+powerful GPU somewhere else — a **free Google Colab**, a **RunPod** rental, or an
+**AWS/GCP/Azure** cloud machine — and pick which model runs where.
+
+You do **not** need to be a developer. No port forwarding, no firewall changes,
+no scary networking. If you can copy-paste and click a button, you can do this.
+
+<p align="center">
+  <img src="../assets/compute-sources-routing.svg" alt="How it fits together: HomePilot on your PC sends a request to OllaBridge Cloud, which relays it over an outbound connection to your GPU worker (Colab / RunPod / AWS); the answer streams back. Local models run on your PC directly." width="860" />
+</p>
+
+**The idea in one sentence:** your HomePilot talks to **OllaBridge Cloud** (a free
+switchboard), and your GPU quietly "dials in" to the same switchboard — so the two
+find each other without you opening anything on your network.
+
+---
+
+## The one golden rule 🔑
+
+> **Sign in to the *same* OllaBridge account in two places:**
+> **(1) inside HomePilot, and (2) on the GPU machine.**
+> That shared account is the only thing that links them together.
+
+Create your free account once at **https://app.ollabridge.com** (sign up),
+then use it in both places below.
+
+---
+
+## What you'll need (2 minutes)
+
+1. **HomePilot** running on your computer. (See the main README to install it.)
+2. A **free OllaBridge account** — https://app.ollabridge.com
+3. **A GPU**, one of:
+   - **Google Colab** — free, great to start, but the session ends after a while.
+   - **RunPod** — cheap rental, stays on as long as you want.
+   - **AWS / GCP / Azure / Vast.ai** — any cloud machine that has an NVIDIA GPU.
+
+Pick one option below. They all follow the same three moves: **install → pair →
+connect.**
+
+---
+
+## Option 1 — Google Colab (free, start here) 🟢
+
+Colab gives you a free GPU in your browser. Perfect for trying this out.
+
+### Step 1 — Open the ready-made notebook
+
+Click this badge (it opens a HomePilot notebook in Colab):
+
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ruslanmv/ollabridge/blob/main/notebooks/homepilot_colab_node.ipynb)
+
+> Not opening? Go to https://colab.research.google.com → **File → Open notebook →
+> GitHub**, paste `ruslanmv/ollabridge`, and choose `notebooks/homepilot_colab_node.ipynb`.
+
+### Step 2 — Turn the GPU on
+
+In Colab's top menu: **Runtime → Change runtime type → Hardware accelerator → T4
+GPU → Save.** (This is free.)
+
+### Step 3 — Fill in the top box, then run each cell
+
+At the top of the notebook there's a small settings box. Set:
+
+- **CLOUD_URL** — leave it as `https://app.ollabridge.com`
+- **RUNTIME** — `chat` (for text) — or `image` / `video` for pictures/videos
+- **MODELS** — e.g. `llama3.2:3b, qwen2.5:0.5b`
+
+Then run the cells one by one (click the ▶ on each, top to bottom). They install
+everything and download your chosen models.
+
+### Step 4 — Pair (this is the fun part)
+
+When you run the **pairing** cell, it prints a short code and a link:
+
+```text
+User code:  ABCD-1234
+Verify at:  https://app.ollabridge.com/link
+Waiting for approval...
+```
+
+Open that link in a new tab, **sign in to OllaBridge**, type the code
+`ABCD-1234`, and click **Approve**. Back in Colab you'll see:
+
+```text
+✅ Paired successfully
+```
+
+### Step 5 — Connect and leave it running
+
+Run the **connect** cell. It shows:
+
+```text
+✅ Cloud device online   —   keep this cell running
+```
+
+That's it — your Colab GPU is now online and waiting. **Leave this Colab tab
+open.** (If you close it or it times out, the GPU simply goes offline and
+HomePilot falls back to your PC — nothing breaks.)
+
+➡️ **Now jump to [“Use it in HomePilot”](#use-it-in-homepilot-the-payoff-) below.**
+
+---
+
+## Option 2 — RunPod (paid, always on) 🟣
+
+RunPod rents you a GPU that stays on. Same three moves, done in a terminal.
+
+1. Sign in at **runpod.io** → **Deploy** a GPU Pod (an RTX 4090 or A100 is plenty).
+   Pick a template that includes **Ubuntu + CUDA** (any "PyTorch" template works).
+2. Open the Pod's **Web Terminal** (a button in the RunPod dashboard).
+3. Paste these five lines and press Enter:
+
+```bash
+curl -fsSL https://ollama.com/install.sh | sh        # install the model runner
+pip install -U ollabridge                            # install the connector
+ollama serve >/tmp/ollama.log 2>&1 &                 # start it in the background
+ollama pull llama3.2:3b                               # download a model
+ollabridge-node cloud-pair --cloud https://app.ollabridge.com --runtime http://127.0.0.1:11434
+```
+
+4. The last line prints a **code + link** (just like Colab Step 4). Open the link,
+   sign in, enter the code, **Approve**.
+5. Finally, keep it connected:
+
+```bash
+ollabridge-node cloud-connect --cloud https://app.ollabridge.com --runtime http://127.0.0.1:11434
+```
+
+Leave that command running. Your RunPod GPU is now online for HomePilot.
+
+> 💡 It stays online (and billing runs) until you **stop the Pod** in RunPod.
+> Stop it when you're done to avoid charges.
+
+---
+
+## Option 3 — AWS, GCP, Azure, or any GPU cloud VM ☁️
+
+Any Ubuntu machine with an NVIDIA GPU works — it's the *exact same five lines* as
+RunPod.
+
+1. Launch a **GPU instance**:
+   - **AWS:** an EC2 `g4dn.xlarge` or `g5.xlarge`, using the **Deep Learning AMI**
+     (it already has NVIDIA drivers).
+   - **GCP / Azure:** any GPU VM with an NVIDIA driver image.
+2. **Connect** to it (SSH, or the cloud console's "Connect" button).
+3. Run the **same five lines** from Option 2, then `cloud-connect`.
+4. Approve the code in your browser. Done.
+
+> If `nvidia-smi` prints an error, your machine doesn't see the GPU yet — pick a
+> GPU image/AMI that includes the NVIDIA driver, or install it, then retry.
+
+---
+
+## Use it in HomePilot (the payoff) 🎉
+
+Back in **HomePilot** (make sure you're signed in to the **same** OllaBridge
+account):
+
+1. Go to **Settings → Compute → Resources** and click **☁ Sync from Cloud**.
+   Your GPU appears as **Online** (with its name, VRAM, and a live heartbeat).
+2. Go to **Settings → Models**. Beside a model, set **“Runs on” → your GPU**, and
+   optionally **“Fallback” → This PC**.
+3. Chat as normal. Under the reply you'll see a small **“Ran on Colab T4”** tag —
+   proof it ran on the GPU, not your laptop.
+
+<p align="center">
+  <img src="../assets/homepilot-connect-illustration.svg" alt="Illustration of HomePilot after connecting: the Resources tab shows This PC (Online) and Google Colab T4 (Online, Ephemeral, heartbeat 8 seconds ago); the deepseek-r1 model has Runs on set to Colab T4, Fallback This PC, and Status Colab T4 online." width="820" />
+</p>
+
+**If the GPU goes offline** (a Colab session ends, a Pod is stopped), HomePilot
+notices the missing heartbeat and automatically uses your **Fallback** — you'll
+see **“Fell back to This PC · Colab T4 offline”**. Your chat keeps working.
+
+---
+
+## If something goes wrong 🛟
+
+| What you see | What to do |
+| ------------ | ---------- |
+| Colab says **no GPU** | Runtime → Change runtime type → **T4 GPU** → Save, then re-run. |
+| The pairing **code expired** | Just run the pairing step again to get a fresh code. |
+| Device **doesn't appear** in HomePilot | Click **Sync from Cloud**. Double-check you signed into the **same** OllaBridge account in both places (the golden rule 🔑). |
+| Device shows **Offline** | Colab sessions time out; re-open the notebook and re-run. HomePilot uses your PC in the meantime. |
+| "Requires more VRAM" next to a model | That model is too big for that GPU — pick a smaller model, or a bigger GPU. |
+
+---
+
+## Advanced — going to production 🔒
+
+Fine for a personal setup out of the box. Before exposing HomePilot to other
+people or the internet, set these and re-check:
+
+> Hit **`GET /compute/readiness`** — it returns `production_ready` plus per-item
+> `checks` and plain-language `warnings`. Ship only when it's green.
+
+| Env var | Why |
+| ------- | --- |
+| `HOMEPILOT_COMPUTE_SECRET_KEY` | Fernet key — encrypts saved endpoint **credentials** at rest (install `cryptography`). |
+| `HOMEPILOT_CLOUD_TOKEN_KEY` | Fernet key — encrypts the per-user **cloud token** at rest. |
+| `API_KEY` | Requires auth on the OpenAI-compatible ingress from off-localhost clients. |
+| `OLLABRIDGE_CLOUD_URL` | Keep the canonical `https://app.ollabridge.com` (or your self-hosted Cloud). |
+| `HOMEPILOT_COMPUTE_BLOCK_PRIVATE` | Optional `true` to also block private/LAN endpoints (default allows them for self-hosted GPUs). |
+
+**What's already enforced:** credentials stay server-side (never in the browser);
+custom endpoint URLs are checked so the cloud metadata service and link-local
+addresses can't be reached (SSRF guard); automatic fallback only happens *before
+the first token*, so a streamed reply never restarts on another device.
+
+**Known limitation:** the compute registry is **single-tenant** today — all
+linked users share one set of sources/devices/routes. For a multi-tenant SaaS,
+scope the registry per user before onboarding untrusted tenants. Single-owner and
+team deployments are unaffected.

--- a/frontend/src/test/computeAdmin.test.ts
+++ b/frontend/src/test/computeAdmin.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { createComputeClient } from "@homepilot/compute-client";
+import type { ApiClient } from "@homepilot/api-client";
+
+/**
+ * PR 3 — the compute-client admin surface. Verifies the wire seam: requests are
+ * snake_case (recursively, for nested modality defaults), responses are
+ * unwrapped + camelized, and DELETE routes hit the right paths.
+ */
+
+type Call = { method: string; path: string; body?: unknown };
+
+function fakeApi(responses: Record<string, unknown>): { api: ApiClient; calls: Call[] } {
+  const calls: Call[] = [];
+  const reply = (path: string) => responses[path] ?? {};
+  const api: ApiClient = {
+    baseUrl: "http://test",
+    get: async (p) => { calls.push({ method: "GET", path: p }); return reply(p) as never; },
+    post: async (p, b) => { calls.push({ method: "POST", path: p, body: b }); return reply(p) as never; },
+    put: async (p, b) => { calls.push({ method: "PUT", path: p, body: b }); return reply(p) as never; },
+    del: async (p) => { calls.push({ method: "DELETE", path: p }); return {} as never; },
+  };
+  return { api, calls };
+}
+
+describe("compute-client admin", () => {
+  it("lists and camelizes sources", async () => {
+    const { api } = fakeApi({
+      "/compute/admin/sources": { sources: [{ id: "s", name: "S", kind: "openai_compatible", base_url: "http://x", credential_ref: "r", enabled: true, execution_type: "direct" }] },
+    });
+    const sources = await createComputeClient(api).listComputeSources();
+    expect(sources[0].baseUrl).toBe("http://x");
+    expect(sources[0].credentialRef).toBe("r");
+    expect(sources[0].executionType).toBe("direct");
+  });
+
+  it("sends per-model routes as snake_case", async () => {
+    const { api, calls } = fakeApi({ "/compute/admin/routes": { route: {} } });
+    await createComputeClient(api).upsertRoute({
+      modality: "chat", modelId: "m", primaryTarget: "device:colab",
+      fallbackTargets: ["local"], strategy: "pinned", privacy: "private_nodes",
+    });
+    const body = calls.find((c) => c.method === "POST")!.body as Record<string, unknown>;
+    expect(body.model_id).toBe("m");
+    expect(body.primary_target).toBe("device:colab");
+    expect(body.fallback_targets).toEqual(["local"]);
+  });
+
+  it("recursively snake-cases nested modality defaults in settings", async () => {
+    const { api, calls } = fakeApi({ "/compute/admin/settings": { settings: {} } });
+    await createComputeClient(api).putComputeSettings({
+      computeMode: "auto",
+      modalityDefaults: {
+        image: { modality: "image", strategy: "prefer_remote", fallbackTargets: ["local"], privacy: "private_nodes" },
+      },
+    });
+    const body = calls.find((c) => c.method === "PUT")!.body as Record<string, unknown>;
+    expect(body.compute_mode).toBe("auto");
+    const md = body.modality_defaults as Record<string, Record<string, unknown>>;
+    expect(md.image.fallback_targets).toEqual(["local"]);
+  });
+
+  it("resolveRoute passes model_id and returns the plan", async () => {
+    const { api, calls } = fakeApi({
+      "/compute/admin/resolve?modality=chat&model_id=m": { modality: "chat", model_id: "m", matched: "route", compute_mode: "local", targets: ["device:colab", "local"] },
+    });
+    const plan = await createComputeClient(api).resolveRoute("chat", "m");
+    expect(plan.matched).toBe("route");
+    expect(plan.targets).toEqual(["device:colab", "local"]);
+    expect(calls[0].path).toContain("model_id=m");
+  });
+
+  it("tests a source and reads local resources", async () => {
+    const { api, calls } = fakeApi({
+      "/compute/admin/sources/oa/test": { ok: true, reason: "Reachable." },
+      "/v1/system/resources": { gpus: [{ available: true, name: "RTX 4090", vram_total_mb: 24576, used_percent: 30 }], cpu: { percent: 12 }, ram: { percent: 40 } },
+    });
+    const client = createComputeClient(api);
+    const t = await client.testComputeSource("oa");
+    expect(t.ok).toBe(true);
+    expect(calls[0]).toMatchObject({ method: "POST", path: "/compute/admin/sources/oa/test" });
+    const res = await client.getLocalResources();
+    expect(res.gpus[0].vramTotalMb).toBe(24576);   // snake→camel
+    expect(res.gpus[0].usedPercent).toBe(30);
+  });
+
+  it("syncs from cloud via POST /compute/admin/sync", async () => {
+    const { api, calls } = fakeApi({
+      "/compute/admin/sync": { ok: true, linked: true, devices: 2, models: 5, source_id: "ollabridge-cloud" },
+    });
+    const r = await createComputeClient(api).syncFromCloud();
+    expect(r).toMatchObject({ linked: true, devices: 2, models: 5 });
+    expect(calls[0]).toMatchObject({ method: "POST", path: "/compute/admin/sync" });
+  });
+
+  it("deletes sources and routes at the right paths", async () => {
+    const { api, calls } = fakeApi({});
+    const client = createComputeClient(api);
+    await client.deleteComputeSource("s 1");
+    await client.deleteRoute("chat", "m/x");
+    expect(calls[0]).toMatchObject({ method: "DELETE", path: "/compute/admin/sources/s%201" });
+    expect(calls[1]).toMatchObject({ method: "DELETE", path: "/compute/admin/routes/chat/m%2Fx" });
+  });
+});

--- a/frontend/src/ui/App.tsx
+++ b/frontend/src/ui/App.tsx
@@ -74,6 +74,7 @@ import {
   type ChatScopedSettings,
 } from './components/ChatSettingsPopover'
 import { MessageMarkdown } from './components/MessageMarkdown'
+import RouteBadge from './components/compute/RouteBadge'
 import { ChatEmptyState } from './components/ChatEmptyState'
 import { AgentIntent, INTENT_COPY } from './components/AgentIntentTiles'
 import { AgentSettingsPanel, type AgentProjectData } from './components/AgentSettingsPanel'
@@ -135,6 +136,15 @@ export type Msg = {
     active_angle?: 'front' | 'left' | 'right' | 'back'
     available_views?: Array<'front' | 'left' | 'right' | 'back'>
     interactive_preview?: boolean
+  } | null
+  // Compute routing diagnostics (P0-2): which device served this reply, and
+  // whether it fell back. Raw shape from /chat (snake_case, not camelized).
+  compute?: {
+    target: string
+    device_id?: string | null
+    label: string
+    fell_back: boolean
+    reason?: string | null
   } | null
   // Phase 4: "Ask before acting" confirmation payload
   confirm?: {
@@ -2320,6 +2330,9 @@ function ChatState({
                     className="w-full rounded-xl border border-white/10 mt-2"
                   />
                 ) : null}
+                {m.role === 'assistant' && m.compute ? (
+                  <div className="mt-2"><RouteBadge compute={m.compute} /></div>
+                ) : null}
               </div>
             )}
             </>)}
@@ -4420,7 +4433,7 @@ ${personalityPrompt || 'You are a friendly voice assistant. Be helpful and warm.
         setMessages((prev) =>
           prev.map((m) =>
             m.id === tmpId
-              ? { ...m, pending: false, animate: true, text: (data.text ?? data.content ?? '…'), media: data.media ?? null }
+              ? { ...m, pending: false, animate: true, text: (data.text ?? data.content ?? '…'), media: data.media ?? null, compute: data.compute ?? null }
               : m
           )
         )
@@ -5094,7 +5107,7 @@ ${personalityPrompt || 'You are a friendly voice assistant. Be helpful and warm.
         setMessages((prev) =>
           prev.map((m) =>
             m.id === tmpId
-              ? { ...m, pending: false, animate: true, text: data.text ?? 'Done.', media: data.media ?? null }
+              ? { ...m, pending: false, animate: true, text: data.text ?? 'Done.', media: data.media ?? null, compute: data.compute ?? null }
               : m
           )
         )

--- a/frontend/src/ui/SettingsPanel.tsx
+++ b/frontend/src/ui/SettingsPanel.tsx
@@ -19,6 +19,7 @@ import {
   Check,
   Loader2,
   Cloud,
+  Cpu,
 } from "lucide-react";
 import OllamaHealthBanner from "./OllamaHealthBanner";
 import OllaBridgeLink from "./components/OllaBridgeLink";
@@ -28,6 +29,9 @@ import { isAccountsUxEnabled } from "./account/featureFlags";
 // Unified model catalog (Batch 8) + relocated OllaBridge provider.
 import { UnifiedModelCatalog } from "./account/UnifiedModelCatalog";
 import OllaBridgeModels from "./components/OllaBridgeModels";
+// Compute Sources & Routing (PR 3) — segmented Resources / Sources / Routing.
+import ComputeSettingsTabs from "./components/compute/ComputeSettingsTabs";
+import ModelExecutionSelector from "./components/compute/ModelExecutionSelector";
 import ProfileSettingsModal from "./ProfileSettingsModal";
 import TtsEngineSection from "./components/TtsEngineSection";
 // Side-effect import: registers the bundled TTS providers (web-speech-api,
@@ -299,6 +303,7 @@ const SECTIONS = [
   { id: "account", label: "Account & Computers", Icon: Cloud },
   { id: "linking", label: "OllaBridge Link", Icon: Cloud },
   { id: "providers", label: "Providers", Icon: Server },
+  { id: "compute", label: "Compute", Icon: Cpu },
   { id: "models", label: "Models", Icon: Boxes },
   { id: "generation", label: "Generation", Icon: SlidersHorizontal },
   { id: "memory", label: "Memory & Safety", Icon: ShieldCheck },
@@ -893,6 +898,14 @@ export default function SettingsPanel({
           </button>
         </div>
         {err ? <div className="mt-2 text-[11px] text-red-400">{err}</div> : null}
+        {modelValue ? (
+          <div className="mt-2 pt-2 border-t border-white/[0.06]">
+            <ModelExecutionSelector
+              modelId={modelValue}
+              modality={(modelType as "image" | "video" | "multimodal") || "chat"}
+            />
+          </div>
+        ) : null}
       </Row>
     );
   }
@@ -1495,6 +1508,18 @@ export default function SettingsPanel({
     );
   }
 
+  function renderCompute() {
+    return (
+      <SettingsCard
+        title="Compute Sources & Routing"
+        description="Choose where each model runs — this PC, a linked GPU, or a hosted endpoint — and how HomePilot falls back when a source is offline."
+        icon={<Cpu size={16} />}
+      >
+        <ComputeSettingsTabs />
+      </SettingsCard>
+    );
+  }
+
   function renderSection() {
     switch (activeSection) {
       case "general": return renderGeneral();
@@ -1502,6 +1527,7 @@ export default function SettingsPanel({
       case "account": return <AccountComputers />;
       case "linking": return <OllaBridgeLink />;
       case "providers": return renderProviders();
+      case "compute": return renderCompute();
       case "models": return renderModels();
       case "generation": return renderGeneration();
       case "memory": return renderMemory();

--- a/frontend/src/ui/components/compute/ComputeJobStatus.tsx
+++ b/frontend/src/ui/components/compute/ComputeJobStatus.tsx
@@ -1,0 +1,135 @@
+/**
+ * ComputeJobStatus — live status for an async image/video job.
+ *
+ * Given a jobId it polls /v1/jobs/{id} and renders queue → routing → running →
+ * done, the selected device and GPU seconds (so the user sees *where* it ran),
+ * and the resulting artifacts or an actionable error. Polling stops on a
+ * terminal state. Polling is used rather than SSE so the component has no
+ * transport dependency; the compute-client also exposes event subscription for
+ * apps that inject one.
+ */
+import React, { useEffect, useRef, useState } from "react";
+import { AlertTriangle, CheckCircle2, Loader2 } from "lucide-react";
+import type { Job } from "@homepilot/types";
+import { computeClient } from "../../api";
+
+const TERMINAL = new Set(["succeeded", "failed", "canceled"]);
+
+export default function ComputeJobStatus({
+  jobId,
+  pollMs = 1500,
+}: {
+  jobId: string;
+  pollMs?: number;
+}) {
+  const [job, setJob] = useState<Job | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const tick = async () => {
+      try {
+        const j = await computeClient.getJobStatus(jobId);
+        if (cancelled) return;
+        setJob(j);
+        setError(null);
+        if (!TERMINAL.has(j.status)) {
+          timer.current = setTimeout(tick, pollMs);
+        }
+      } catch (e) {
+        if (cancelled) return;
+        setError(e instanceof Error ? e.message : "Failed to fetch job");
+        timer.current = setTimeout(tick, pollMs * 2);
+      }
+    };
+
+    void tick();
+    return () => {
+      cancelled = true;
+      if (timer.current) clearTimeout(timer.current);
+    };
+  }, [jobId, pollMs]);
+
+  if (error && !job) {
+    return (
+      <div className="px-3 py-2 rounded-xl bg-red-500/10 border border-red-500/20 text-red-300 text-xs">
+        {error}
+      </div>
+    );
+  }
+  if (!job) {
+    return (
+      <div className="text-xs text-white/50 inline-flex items-center gap-2">
+        <Loader2 size={14} className="animate-spin" /> Starting…
+      </div>
+    );
+  }
+
+  const pct = Math.max(0, Math.min(100, Math.round(job.progress || 0)));
+  const running = !TERMINAL.has(job.status);
+
+  return (
+    <div className="rounded-2xl border border-white/10 bg-white/[0.02] p-4 space-y-3">
+      <div className="flex items-center justify-between text-sm">
+        <span className="flex items-center gap-2 text-white/80">
+          {job.status === "succeeded" ? (
+            <CheckCircle2 size={16} className="text-emerald-400" />
+          ) : job.status === "failed" || job.status === "canceled" ? (
+            <AlertTriangle size={16} className="text-red-400" />
+          ) : (
+            <Loader2 size={16} className="animate-spin text-cyan-300" />
+          )}
+          <span className="capitalize">{job.status}</span>
+          {job.model && <span className="text-white/40">· {job.model}</span>}
+        </span>
+        <span className="text-xs text-white/40">
+          {job.selectedDeviceId ? `on ${job.selectedDeviceId}` : ""}
+          {job.gpuSeconds != null ? ` · ${job.gpuSeconds.toFixed(1)}s GPU` : ""}
+        </span>
+      </div>
+
+      {running && (
+        <div className="h-1.5 w-full rounded-full bg-white/10 overflow-hidden">
+          <div
+            className="h-full bg-cyan-400/70 transition-[width] duration-500"
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+      )}
+
+      {job.error && (
+        <div className="px-3 py-2 rounded-xl bg-red-500/10 border border-red-500/20 text-red-300 text-xs">
+          {job.error.message}
+          <span className="text-red-300/60"> ({job.error.code})</span>
+        </div>
+      )}
+
+      {job.output?.artifacts?.length ? (
+        <div className="flex flex-wrap gap-2">
+          {job.output.artifacts.map((a, i) =>
+            a.contentType.startsWith("image/") ? (
+              <img
+                key={i}
+                src={a.url}
+                alt={`artifact ${i + 1}`}
+                className="h-24 w-24 object-cover rounded-lg border border-white/10"
+              />
+            ) : (
+              <a
+                key={i}
+                href={a.url}
+                target="_blank"
+                rel="noreferrer"
+                className="text-xs text-cyan-300 underline"
+              >
+                Artifact {i + 1}
+              </a>
+            ),
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/ui/components/compute/ComputeResourcesPanel.test.tsx
+++ b/frontend/src/ui/components/compute/ComputeResourcesPanel.test.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+const testComputeSource = vi.hoisted(() => vi.fn(async () => ({ ok: true, reason: "Reachable." })));
+const putComputeSettings = vi.hoisted(() => vi.fn(async (p) => ({ computeMode: p.computeMode })));
+const syncFromCloud = vi.hoisted(() => vi.fn(async () => ({ ok: true, linked: true, devices: 1, models: 4 })));
+
+vi.mock("../../api", () => ({
+  computeClient: {
+    getComputeStatus: async () => ({ message: "Using this PC — Private GPU", localGpuAvailable: true }),
+    getLocalResources: async () => ({
+      gpus: [{ index: 0, available: true, name: "GeForce RTX 4090", vramTotalMb: 24576, usedPercent: 25, utilizationPercent: 10 }],
+      gpu: { available: true },
+      cpu: { name: "Core i9-13900K", logicalCores: 32, percent: 12 },
+      ram: { percent: 40 },
+    }),
+    listComputeSources: async () => [
+      { id: "colab", name: "Google Colab", kind: "ollabridge", enabled: true, executionType: "relay" },
+    ],
+    listComputeDevices: async () => [
+      { id: "t4", sourceId: "colab", name: "Colab T4", online: true, onlineEffective: true, ephemeral: true,
+        gpuName: "NVIDIA T4", vramMb: 16384, capacity: 1, activeJobs: 0, heartbeatAgeS: 8 },
+    ],
+    listModelManifests: async () => [],
+    getComputeSettings: async () => ({ computeMode: "local" }),
+    testComputeSource,
+    putComputeSettings,
+    syncFromCloud,
+    deleteComputeSource: async () => undefined,
+  },
+}));
+
+import ComputeResourcesPanel from "./ComputeResourcesPanel";
+
+beforeEach(() => {
+  testComputeSource.mockClear();
+  putComputeSettings.mockClear();
+  syncFromCloud.mockClear();
+});
+
+describe("ComputeResourcesPanel", () => {
+  it("renders local GPU, an ephemeral online device, and tests a source", async () => {
+    render(<ComputeResourcesPanel />);
+
+    await waitFor(() => expect(screen.getByText("GeForce RTX 4090")).toBeInTheDocument());
+    // Local status + device presentation.
+    expect(screen.getByText(/Using this PC/)).toBeInTheDocument();
+    expect(screen.getByText("Colab T4")).toBeInTheDocument();
+    expect(screen.getByText("Ephemeral")).toBeInTheDocument();
+    // "Online" appears for both This PC and the device badge.
+    expect(screen.getAllByText("Online").length).toBeGreaterThanOrEqual(1);
+
+    // Test action calls the source-test endpoint and shows the result.
+    fireEvent.click(screen.getByText("Test"));
+    await waitFor(() => expect(testComputeSource).toHaveBeenCalledWith("colab"));
+    await waitFor(() => expect(screen.getByText("✓ Reachable")).toBeInTheDocument());
+  });
+
+  it("syncs devices from OllaBridge Cloud and reports the result", async () => {
+    render(<ComputeResourcesPanel />);
+    await waitFor(() => expect(screen.getByText("Sync from Cloud")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Sync from Cloud"));
+    await waitFor(() => expect(syncFromCloud).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(screen.getByText(/Synced 1 device · 4 models/)).toBeInTheDocument(),
+    );
+  });
+
+  it("toggles the global remote-resources default to auto", async () => {
+    render(<ComputeResourcesPanel />);
+    await waitFor(() => expect(screen.getByText(/Use remote resources/)).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("checkbox"));
+    await waitFor(() =>
+      expect(putComputeSettings).toHaveBeenCalledWith({ computeMode: "auto" }),
+    );
+  });
+});

--- a/frontend/src/ui/components/compute/ComputeResourcesPanel.tsx
+++ b/frontend/src/ui/components/compute/ComputeResourcesPanel.tsx
@@ -1,0 +1,340 @@
+/**
+ * ComputeResourcesPanel — the "Resources" tab.
+ *
+ * One glance at everything that can run a request:
+ *   • This PC — live CPU / RAM / per-GPU VRAM meters (multi-GPU aware).
+ *   • Remote sources — each with its devices, status badges (Online / Busy /
+ *     Offline / Ephemeral), GPU/VRAM, model count and heartbeat age, plus
+ *     per-source actions (Test · Sync · Disconnect).
+ *   • A global "Use remote resources" default that never overrides an explicit
+ *     per-model route.
+ */
+import React, { useCallback, useEffect, useState } from "react";
+import {
+  Cloud, Cpu, Loader2, MemoryStick, Plug, RefreshCw, Trash2, Wifi, WifiOff, Zap,
+} from "lucide-react";
+import type {
+  ComputeDevice, ComputeSource, ComputeStatus, LocalResources, ModelManifest,
+} from "@homepilot/types";
+import { computeClient } from "../../api";
+
+function heartbeat(d: ComputeDevice): string {
+  if (d.heartbeatAgeS == null) return "—";
+  const s = Math.max(0, Math.round(d.heartbeatAgeS));
+  return s < 60 ? `${s}s ago` : `${Math.round(s / 60)}m ago`;
+}
+
+function deviceBadge(d: ComputeDevice): { label: string; cls: string } {
+  const online = d.onlineEffective ?? d.online;
+  if (!online) return { label: "Offline", cls: "bg-white/5 border-white/10 text-white/40" };
+  if (d.capacity > 0 && d.activeJobs >= d.capacity)
+    return { label: "Busy", cls: "bg-amber-500/10 border-amber-500/20 text-amber-300" };
+  return { label: "Online", cls: "bg-emerald-500/10 border-emerald-500/20 text-emerald-300" };
+}
+
+function Meter({ label, percent, tone = "cyan" }: { label: string; percent?: number | null; tone?: string }) {
+  const p = Math.max(0, Math.min(100, Math.round(percent ?? 0)));
+  const bar =
+    tone === "violet" ? "bg-violet-400/70" : tone === "emerald" ? "bg-emerald-400/70" : "bg-cyan-400/70";
+  return (
+    <div className="min-w-[92px]">
+      <div className="flex justify-between text-[10px] text-white/40 mb-0.5">
+        <span>{label}</span>
+        <span>{percent == null ? "—" : `${p}%`}</span>
+      </div>
+      <div className="h-1.5 w-full rounded-full bg-white/10 overflow-hidden">
+        <div className={`h-full ${bar}`} style={{ width: `${p}%` }} />
+      </div>
+    </div>
+  );
+}
+
+export default function ComputeResourcesPanel({
+  onConnectSource,
+}: {
+  onConnectSource?: () => void;
+}) {
+  const [status, setStatus] = useState<ComputeStatus | null>(null);
+  const [local, setLocal] = useState<LocalResources | null>(null);
+  const [sources, setSources] = useState<ComputeSource[]>([]);
+  const [devices, setDevices] = useState<ComputeDevice[]>([]);
+  const [manifests, setManifests] = useState<ModelManifest[]>([]);
+  const [remoteDefault, setRemoteDefault] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [tested, setTested] = useState<Record<string, string>>({});
+  const [error, setError] = useState<string | null>(null);
+  const [syncing, setSyncing] = useState(false);
+  const [syncMsg, setSyncMsg] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [st, res, srcs, devs, mans, settings] = await Promise.all([
+        computeClient.getComputeStatus().catch(() => null),
+        computeClient.getLocalResources().catch(() => null),
+        computeClient.listComputeSources(),
+        computeClient.listComputeDevices(),
+        computeClient.listModelManifests().catch(() => []),
+        computeClient.getComputeSettings().catch(() => null),
+      ]);
+      setStatus(st);
+      setLocal(res);
+      setSources(srcs);
+      setDevices(devs);
+      setManifests(mans);
+      setRemoteDefault(settings?.computeMode === "auto" || settings?.computeMode === "ollabridge_cloud");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load resources");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const modelsFor = (deviceId: string) =>
+    manifests.filter((m) => m.deviceIds.includes(deviceId)).length;
+
+  const toggleRemoteDefault = useCallback(async () => {
+    const next = !remoteDefault;
+    setRemoteDefault(next);
+    try {
+      await computeClient.putComputeSettings({ computeMode: next ? "auto" : "local" });
+    } catch {
+      setRemoteDefault(!next); // revert on failure
+    }
+  }, [remoteDefault]);
+
+  const testSource = useCallback(async (id: string) => {
+    setBusyId(id);
+    try {
+      const r = await computeClient.testComputeSource(id);
+      setTested((t) => ({ ...t, [id]: r.ok ? "✓ Reachable" : r.reason || "Unreachable" }));
+    } catch (e) {
+      setTested((t) => ({ ...t, [id]: e instanceof Error ? e.message : "Test failed" }));
+    } finally {
+      setBusyId(null);
+    }
+  }, []);
+
+  const syncFromCloud = useCallback(async () => {
+    setSyncing(true);
+    setSyncMsg(null);
+    try {
+      const r = await computeClient.syncFromCloud();
+      if (!r.linked) {
+        setSyncMsg(r.reason || "Link your OllaBridge account to sync devices.");
+      } else {
+        setSyncMsg(`Synced ${r.devices} device${r.devices === 1 ? "" : "s"} · ${r.models} model${r.models === 1 ? "" : "s"} from OllaBridge Cloud.`);
+        await load();
+      }
+    } catch (e) {
+      setSyncMsg(e instanceof Error ? e.message : "Sync failed");
+    } finally {
+      setSyncing(false);
+    }
+  }, [load]);
+
+  const disconnect = useCallback(async (id: string) => {
+    setBusyId(id);
+    try {
+      await computeClient.deleteComputeSource(id);
+      await load();
+    } finally {
+      setBusyId(null);
+    }
+  }, [load]);
+
+  const gpus = local?.gpus?.length ? local.gpus : local?.gpu?.available ? [local.gpu] : [];
+  const localOnline = status?.localGpuAvailable ?? (gpus.length > 0);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-sm font-semibold text-white">Resources</h3>
+          <p className="text-xs text-white/50">Live capacity across this PC and connected sources.</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => void syncFromCloud()}
+            disabled={syncing}
+            className="h-9 px-3 rounded-xl bg-white/5 hover:bg-white/10 border border-white/10 text-xs text-white/70 inline-flex items-center gap-1.5"
+          >
+            {syncing ? <Loader2 size={14} className="animate-spin" /> : <Cloud size={14} />}
+            Sync from Cloud
+          </button>
+          {onConnectSource && (
+            <button
+              onClick={onConnectSource}
+              className="h-9 px-3 rounded-xl bg-white/5 hover:bg-white/10 border border-white/10 text-xs text-white/70 inline-flex items-center gap-1.5"
+            >
+              <Plug size={14} /> Connect source
+            </button>
+          )}
+          <button
+            onClick={() => void load()}
+            className="h-9 px-3 rounded-xl bg-white/5 hover:bg-white/10 border border-white/10 text-xs text-white/70 inline-flex items-center gap-1.5"
+          >
+            {loading ? <Loader2 size={14} className="animate-spin" /> : <RefreshCw size={14} />}
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      {status && (
+        <div className="rounded-2xl border border-white/10 bg-white/[0.02] p-4 flex items-center gap-3">
+          <Zap size={16} className="text-cyan-300 shrink-0" />
+          <div className="text-sm text-white/80">{status.message}</div>
+        </div>
+      )}
+      {error && (
+        <div className="px-3 py-2 rounded-xl bg-red-500/10 border border-red-500/20 text-red-300 text-xs">
+          {error}
+        </div>
+      )}
+      {syncMsg && (
+        <div className="px-3 py-2 rounded-xl bg-cyan-500/10 border border-cyan-500/20 text-cyan-200 text-xs">
+          {syncMsg}
+        </div>
+      )}
+
+      {/* This PC */}
+      <div className="rounded-2xl border border-white/10 bg-white/[0.02] p-4 space-y-3">
+        <div className="flex items-center justify-between">
+          <div className="text-sm font-medium text-white">This PC</div>
+          <span className={`text-[11px] px-2.5 py-1 rounded-full border ${
+            localOnline ? "bg-emerald-500/10 border-emerald-500/20 text-emerald-300" : "bg-white/5 border-white/10 text-white/40"
+          }`}>
+            {localOnline ? "Online" : "Offline"}
+          </span>
+        </div>
+        <div className="space-y-2">
+          {local?.cpu?.name && (
+            <div className="flex items-center justify-between gap-4">
+              <span className="flex items-center gap-2 text-xs text-white/70">
+                <Cpu size={14} className="text-white/40" />
+                {local.cpu.name}
+                {local.cpu.logicalCores ? <span className="text-white/40">· {local.cpu.logicalCores} threads</span> : null}
+              </span>
+              <div className="flex items-center gap-3">
+                <Meter label="CPU" percent={local.cpu.percent} tone="violet" />
+                {local.ram?.percent != null && <Meter label="RAM" percent={local.ram.percent} tone="emerald" />}
+              </div>
+            </div>
+          )}
+          {gpus.map((g, i) => (
+            <div key={i} className="flex items-center justify-between gap-4">
+              <span className="flex items-center gap-2 text-xs text-white/70">
+                <MemoryStick size={14} className="text-white/40" />
+                {g.name || `GPU ${g.index ?? i}`}
+                {g.vramTotalMb ? <span className="text-white/40">· {Math.round(g.vramTotalMb / 1024)} GB</span> : null}
+              </span>
+              <div className="flex items-center gap-3">
+                <Meter label="VRAM" percent={g.usedPercent} />
+                {g.utilizationPercent != null && <Meter label="GPU" percent={g.utilizationPercent} tone="violet" />}
+              </div>
+            </div>
+          ))}
+          {gpus.length === 0 && (
+            <div className="text-xs text-white/40">No local GPU detected — Ollama/ComfyUI may run on CPU.</div>
+          )}
+        </div>
+      </div>
+
+      {/* Global default */}
+      <label className="rounded-2xl border border-white/10 bg-white/[0.02] p-4 flex items-center justify-between cursor-pointer">
+        <div>
+          <div className="text-sm text-white">Use remote resources for complex tasks</div>
+          <div className="text-xs text-white/40">A soft default — explicit per-model routes always win.</div>
+        </div>
+        <input type="checkbox" checked={remoteDefault} onChange={() => void toggleRemoteDefault()} className="sr-only peer" />
+        <span className="w-10 h-6 rounded-full bg-white/10 peer-checked:bg-cyan-500/60 relative transition-colors">
+          <span className={`absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white transition-transform ${remoteDefault ? "translate-x-4" : ""}`} />
+        </span>
+      </label>
+
+      {/* Remote sources */}
+      {sources.filter((s) => s.kind !== "local").map((s) => {
+        const devs = devices.filter((d) => d.sourceId === s.id);
+        return (
+          <div key={s.id} className="rounded-2xl border border-white/10 bg-white/[0.02] p-4 space-y-3">
+            <div className="flex items-center justify-between">
+              <div>
+                <div className="text-sm font-medium text-white">{s.name}</div>
+                <div className="text-xs text-white/40">{s.kind}{s.baseUrl ? ` · ${s.baseUrl}` : ""}</div>
+              </div>
+              <div className="flex items-center gap-1.5">
+                <button
+                  onClick={() => void testSource(s.id)}
+                  disabled={busyId === s.id}
+                  className="h-8 px-2.5 rounded-lg bg-white/5 hover:bg-white/10 border border-white/10 text-[11px] text-white/70 inline-flex items-center gap-1"
+                >
+                  {busyId === s.id ? <Loader2 size={12} className="animate-spin" /> : <Wifi size={12} />} Test
+                </button>
+                <button
+                  onClick={() => void load()}
+                  className="h-8 px-2.5 rounded-lg bg-white/5 hover:bg-white/10 border border-white/10 text-[11px] text-white/70 inline-flex items-center gap-1"
+                >
+                  <RefreshCw size={12} /> Sync
+                </button>
+                <button
+                  onClick={() => void disconnect(s.id)}
+                  aria-label={`Disconnect ${s.name}`}
+                  className="h-8 w-8 grid place-items-center rounded-lg bg-white/5 hover:bg-red-500/10 border border-white/10 text-white/50 hover:text-red-300"
+                >
+                  <Trash2 size={12} />
+                </button>
+              </div>
+            </div>
+            {tested[s.id] && <div className="text-[11px] text-white/50">{tested[s.id]}</div>}
+            {devs.length === 0 ? (
+              <div className="text-xs text-white/40">No devices reported yet.</div>
+            ) : (
+              <ul className="space-y-2">
+                {devs.map((d) => {
+                  const badge = deviceBadge(d);
+                  return (
+                    <li key={d.id} className="flex items-center justify-between text-xs">
+                      <span className="flex items-center gap-2 text-white/80">
+                        <Cpu size={14} className="text-white/40" />
+                        {d.name || d.id}
+                        {d.ephemeral && (
+                          <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-amber-500/10 text-amber-300 border border-amber-500/20">
+                            Ephemeral
+                          </span>
+                        )}
+                      </span>
+                      <span className="flex items-center gap-3 text-white/50">
+                        {d.gpuName && <span>{d.gpuName}</span>}
+                        {d.vramMb != null && <span>{Math.round(d.vramMb / 1024)} GB</span>}
+                        <span>{modelsFor(d.id)} models</span>
+                        <span>{heartbeat(d)}</span>
+                        {(d.onlineEffective ?? d.online) ? (
+                          <Wifi size={14} className="text-emerald-400" />
+                        ) : (
+                          <WifiOff size={14} className="text-white/30" />
+                        )}
+                        <span className={`text-[10px] px-2 py-0.5 rounded-full border ${badge.cls}`}>{badge.label}</span>
+                      </span>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+        );
+      })}
+
+      {!loading && sources.filter((s) => s.kind !== "local").length === 0 && (
+        <div className="text-xs text-white/40">
+          No remote compute sources connected yet.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/ui/components/compute/ComputeSettingsTabs.tsx
+++ b/frontend/src/ui/components/compute/ComputeSettingsTabs.tsx
@@ -1,0 +1,46 @@
+/**
+ * ComputeSettingsTabs — segmented navigation for the Compute section.
+ *
+ * Splits the feature into the three concerns the design separates — inventory
+ * (Resources), connections (Sources), and policy (Routing) — instead of one
+ * long scroll. "Connect source" on the Resources tab deep-links to Sources.
+ */
+import React, { useState } from "react";
+import { Cpu, Server, SlidersHorizontal } from "lucide-react";
+import ComputeResourcesPanel from "./ComputeResourcesPanel";
+import ComputeSourcesSettings from "./ComputeSourcesSettings";
+import RoutingPolicyEditor from "./RoutingPolicyEditor";
+
+type Tab = "resources" | "sources" | "routing";
+
+const TABS: { id: Tab; label: string; Icon: typeof Cpu }[] = [
+  { id: "resources", label: "Resources", Icon: Cpu },
+  { id: "sources", label: "Sources", Icon: Server },
+  { id: "routing", label: "Routing", Icon: SlidersHorizontal },
+];
+
+export default function ComputeSettingsTabs() {
+  const [tab, setTab] = useState<Tab>("resources");
+
+  return (
+    <div className="space-y-4">
+      <div className="inline-flex rounded-xl border border-white/10 bg-black/30 p-1">
+        {TABS.map(({ id, label, Icon }) => (
+          <button
+            key={id}
+            onClick={() => setTab(id)}
+            className={`h-9 px-4 rounded-lg text-xs font-medium inline-flex items-center gap-1.5 transition-colors ${
+              tab === id ? "bg-white/10 text-white" : "text-white/50 hover:text-white/80"
+            }`}
+          >
+            <Icon size={14} /> {label}
+          </button>
+        ))}
+      </div>
+
+      {tab === "resources" && <ComputeResourcesPanel onConnectSource={() => setTab("sources")} />}
+      {tab === "sources" && <ComputeSourcesSettings />}
+      {tab === "routing" && <RoutingPolicyEditor />}
+    </div>
+  );
+}

--- a/frontend/src/ui/components/compute/ComputeSourcesSettings.tsx
+++ b/frontend/src/ui/components/compute/ComputeSourcesSettings.tsx
@@ -1,0 +1,273 @@
+/**
+ * ComputeSourcesSettings — the "Sources" tab.
+ *
+ * Connect, edit, and disconnect compute sources: local, an OllaBridge linked
+ * device/relay, or a direct OpenAI-compatible endpoint. Credentials are
+ * write-only — the field is send-once and never read back; the backend keeps the
+ * secret server-side and returns only a credentialRef.
+ */
+import React, { useCallback, useEffect, useState } from "react";
+import { Loader2, Plus, Save, Trash2, Wifi } from "lucide-react";
+import type { ComputeSource, SourceKind } from "@homepilot/types";
+import { computeClient } from "../../api";
+
+const KINDS: { value: SourceKind; label: string; wantsUrl: boolean; wantsCred: boolean }[] = [
+  { value: "ollabridge", label: "OllaBridge linked device", wantsUrl: false, wantsCred: false },
+  { value: "openai_compatible", label: "OpenAI-compatible endpoint", wantsUrl: true, wantsCred: true },
+  { value: "comfyui", label: "Remote ComfyUI endpoint", wantsUrl: true, wantsCred: false },
+  { value: "custom", label: "Custom", wantsUrl: true, wantsCred: true },
+];
+
+interface DraftSource {
+  id: string;
+  name: string;
+  kind: SourceKind;
+  baseUrl: string;
+  credential: string;
+  enabled: boolean;
+}
+
+const EMPTY: DraftSource = {
+  id: "",
+  name: "",
+  kind: "openai_compatible",
+  baseUrl: "",
+  credential: "",
+  enabled: true,
+};
+
+export default function ComputeSourcesSettings() {
+  const [sources, setSources] = useState<ComputeSource[]>([]);
+  const [draft, setDraft] = useState<DraftSource | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [tested, setTested] = useState<Record<string, string>>({});
+  const [testingId, setTestingId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      setSources(await computeClient.listComputeSources());
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load sources");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const save = useCallback(async () => {
+    if (!draft) return;
+    if (!draft.id.trim()) {
+      setError("An id is required (e.g. my-vllm).");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await computeClient.upsertComputeSource({
+        id: draft.id.trim(),
+        name: draft.name.trim() || draft.id.trim(),
+        kind: draft.kind,
+        baseUrl: draft.baseUrl.trim() || undefined,
+        enabled: draft.enabled,
+        ...(draft.credential ? { credential: draft.credential } : {}),
+      });
+      setDraft(null);
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Save failed");
+    } finally {
+      setBusy(false);
+    }
+  }, [draft, load]);
+
+  const toggle = useCallback(
+    async (s: ComputeSource) => {
+      await computeClient.upsertComputeSource({ id: s.id, kind: s.kind, enabled: !s.enabled });
+      await load();
+    },
+    [load],
+  );
+
+  const remove = useCallback(
+    async (id: string) => {
+      await computeClient.deleteComputeSource(id);
+      await load();
+    },
+    [load],
+  );
+
+  const test = useCallback(async (id: string) => {
+    setTestingId(id);
+    try {
+      const r = await computeClient.testComputeSource(id);
+      setTested((t) => ({ ...t, [id]: r.ok ? "✓ Reachable" : r.reason || "Unreachable" }));
+    } catch (e) {
+      setTested((t) => ({ ...t, [id]: e instanceof Error ? e.message : "Test failed" }));
+    } finally {
+      setTestingId(null);
+    }
+  }, []);
+
+  const kindMeta = draft ? KINDS.find((k) => k.value === draft.kind) : undefined;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-sm font-semibold text-white">Compute sources</h3>
+          <p className="text-xs text-white/50">Where HomePilot may run models.</p>
+        </div>
+        <button
+          onClick={() => setDraft({ ...EMPTY })}
+          className="h-9 px-3 rounded-xl bg-white/5 hover:bg-white/10 border border-white/10 text-xs text-white/70 inline-flex items-center gap-1.5"
+        >
+          <Plus size={14} /> Connect source
+        </button>
+      </div>
+
+      {error && (
+        <div className="px-3 py-2 rounded-xl bg-red-500/10 border border-red-500/20 text-red-300 text-xs">
+          {error}
+        </div>
+      )}
+
+      {loading && <Loader2 size={16} className="animate-spin text-white/40" />}
+
+      <ul className="space-y-2">
+        {sources.map((s) => (
+          <li
+            key={s.id}
+            className="rounded-2xl border border-white/10 bg-white/[0.02] p-4 flex items-center justify-between"
+          >
+            <div>
+              <div className="text-sm text-white">{s.name}</div>
+              <div className="text-xs text-white/40">
+                {s.kind}
+                {s.baseUrl ? ` · ${s.baseUrl}` : ""}
+                {s.credentialRef ? " · key set" : ""}
+              </div>
+              {tested[s.id] && <div className="text-[11px] text-white/50 mt-1">{tested[s.id]}</div>}
+            </div>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => void test(s.id)}
+                disabled={testingId === s.id}
+                className="h-8 px-2.5 rounded-lg bg-white/5 hover:bg-white/10 border border-white/10 text-[11px] text-white/70 inline-flex items-center gap-1"
+              >
+                {testingId === s.id ? <Loader2 size={12} className="animate-spin" /> : <Wifi size={12} />} Test
+              </button>
+              <button
+                onClick={() => void toggle(s)}
+                className={`text-[11px] px-2.5 py-1 rounded-full border ${
+                  s.enabled
+                    ? "bg-emerald-500/10 border-emerald-500/20 text-emerald-300"
+                    : "bg-white/5 border-white/10 text-white/40"
+                }`}
+              >
+                {s.enabled ? "Enabled" : "Disabled"}
+              </button>
+              <button
+                onClick={() => void remove(s.id)}
+                aria-label={`Delete ${s.name}`}
+                className="h-8 w-8 grid place-items-center rounded-xl bg-white/5 hover:bg-red-500/10 border border-white/10 text-white/50 hover:text-red-300"
+              >
+                <Trash2 size={14} />
+              </button>
+            </div>
+          </li>
+        ))}
+        {!loading && sources.length === 0 && (
+          <li className="text-xs text-white/40">No sources yet.</li>
+        )}
+      </ul>
+
+      {draft && (
+        <div className="rounded-2xl border border-white/10 bg-black/30 p-4 space-y-3">
+          <div className="grid grid-cols-2 gap-3">
+            <Field label="Id">
+              <input
+                value={draft.id}
+                onChange={(e) => setDraft({ ...draft, id: e.target.value })}
+                placeholder="my-vllm"
+                className="w-full h-10 rounded-xl bg-black/40 border border-white/10 px-3 text-sm text-white placeholder:text-white/30 outline-none focus:border-cyan-400/50"
+              />
+            </Field>
+            <Field label="Name">
+              <input
+                value={draft.name}
+                onChange={(e) => setDraft({ ...draft, name: e.target.value })}
+                placeholder="My vLLM"
+                className="w-full h-10 rounded-xl bg-black/40 border border-white/10 px-3 text-sm text-white placeholder:text-white/30 outline-none focus:border-cyan-400/50"
+              />
+            </Field>
+          </div>
+          <Field label="Kind">
+            <select
+              value={draft.kind}
+              onChange={(e) => setDraft({ ...draft, kind: e.target.value as SourceKind })}
+              className="w-full h-10 rounded-xl bg-black/40 border border-white/10 px-3 text-sm text-white outline-none focus:border-cyan-400/50"
+            >
+              {KINDS.map((k) => (
+                <option key={k.value} value={k.value}>
+                  {k.label}
+                </option>
+              ))}
+            </select>
+          </Field>
+          {kindMeta?.wantsUrl && (
+            <Field label="Base URL">
+              <input
+                value={draft.baseUrl}
+                onChange={(e) => setDraft({ ...draft, baseUrl: e.target.value })}
+                placeholder="https://host:port"
+                className="w-full h-10 rounded-xl bg-black/40 border border-white/10 px-3 text-sm text-white placeholder:text-white/30 outline-none focus:border-cyan-400/50"
+              />
+            </Field>
+          )}
+          {kindMeta?.wantsCred && (
+            <Field label="API key (write-only)">
+              <input
+                type="password"
+                value={draft.credential}
+                onChange={(e) => setDraft({ ...draft, credential: e.target.value })}
+                placeholder="stored server-side, never shown again"
+                className="w-full h-10 rounded-xl bg-black/40 border border-white/10 px-3 text-sm text-white placeholder:text-white/30 outline-none focus:border-cyan-400/50"
+              />
+            </Field>
+          )}
+          <div className="flex items-center gap-2 justify-end">
+            <button
+              onClick={() => setDraft(null)}
+              className="h-9 px-3 rounded-xl bg-white/5 hover:bg-white/10 border border-white/10 text-xs text-white/60"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={() => void save()}
+              disabled={busy}
+              className="h-9 px-3 rounded-xl bg-cyan-500/20 hover:bg-cyan-500/30 border border-cyan-400/30 text-xs text-cyan-100 inline-flex items-center gap-1.5 disabled:opacity-50"
+            >
+              {busy ? <Loader2 size={14} className="animate-spin" /> : <Save size={14} />} Save
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="block space-y-1">
+      <span className="text-xs text-white/50">{label}</span>
+      {children}
+    </label>
+  );
+}

--- a/frontend/src/ui/components/compute/ModelExecutionSelector.test.tsx
+++ b/frontend/src/ui/components/compute/ModelExecutionSelector.test.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+// Mock the app api module so the component talks to an in-memory client.
+// vi.mock is hoisted, so the fns must be created via vi.hoisted.
+const { upsertRoute, deleteRoute } = vi.hoisted(() => ({
+  upsertRoute: vi.fn(async (r: unknown) => r),
+  deleteRoute: vi.fn(async () => undefined),
+}));
+
+vi.mock("../../api", () => ({
+  computeClient: {
+    listComputeSources: async () => [
+      { id: "oa", name: "My vLLM", kind: "openai_compatible", enabled: true, executionType: "direct" },
+    ],
+    listComputeDevices: async () => [
+      { id: "colab", sourceId: "ob", name: "Colab T4", online: true, ephemeral: true, capacity: 1, activeJobs: 0, onlineEffective: true },
+    ],
+    listModelManifests: async () => [],
+    listRoutes: async () => [],
+    upsertRoute,
+    deleteRoute,
+  },
+}));
+
+import ModelExecutionSelector from "./ModelExecutionSelector";
+
+beforeEach(() => {
+  upsertRoute.mockClear();
+  deleteRoute.mockClear();
+});
+
+describe("ModelExecutionSelector", () => {
+  it("renders execution options and pins a route on change", async () => {
+    render(<ModelExecutionSelector modelId="deepseek-r1" modality="chat" />);
+
+    // The "Runs on" select appears once data loads.
+    await waitFor(() => expect(screen.getByText("Runs on")).toBeInTheDocument());
+    const selects = screen.getAllByRole("combobox");
+    const runsOn = selects[0];
+
+    // The "Runs on" select offers Auto, This PC, and the online Colab device.
+    const labels = Array.from(runsOn.querySelectorAll("option")).map((o) => o.textContent);
+    expect(labels).toEqual(expect.arrayContaining(["Auto", "This PC", "Colab T4"]));
+
+    fireEvent.change(runsOn, { target: { value: "device:colab" } });
+
+    await waitFor(() =>
+      expect(upsertRoute).toHaveBeenCalledWith(
+        expect.objectContaining({ modelId: "deepseek-r1", primaryTarget: "device:colab" }),
+      ),
+    );
+  });
+});

--- a/frontend/src/ui/components/compute/ModelExecutionSelector.tsx
+++ b/frontend/src/ui/components/compute/ModelExecutionSelector.tsx
@@ -1,0 +1,180 @@
+/**
+ * ModelExecutionSelector — the per-model "Runs on / Fallback" control.
+ *
+ * Drop this beside any model (Models tab, persona model picker) to bind where it
+ * executes. "Auto" clears the binding (the routing policy decides); anything else
+ * pins a ModelRoute. Options that can't serve the model are shown but disabled
+ * with the reason ("Offline", "Requires 20 GB VRAM", …).
+ *
+ * Self-contained: fetches sources/devices/manifests and the model's current
+ * route on mount, and persists changes via the compute admin API.
+ */
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { Loader2 } from "lucide-react";
+import type {
+  ComputeDevice,
+  ComputeSource,
+  Modality,
+  ModelManifest,
+  ModelRoute,
+} from "@homepilot/types";
+import { computeClient } from "../../api";
+import { buildTargetOptions, targetLabel, type TargetOption } from "./targets";
+
+interface Props {
+  modelId: string;
+  modality?: Modality;
+  onChange?: (route: ModelRoute | null) => void;
+}
+
+export default function ModelExecutionSelector({ modelId, modality = "chat", onChange }: Props) {
+  const [sources, setSources] = useState<ComputeSource[]>([]);
+  const [devices, setDevices] = useState<ComputeDevice[]>([]);
+  const [manifests, setManifests] = useState<ModelManifest[]>([]);
+  const [route, setRoute] = useState<ModelRoute | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [srcs, devs, mans, routes] = await Promise.all([
+        computeClient.listComputeSources(),
+        computeClient.listComputeDevices(),
+        computeClient.listModelManifests().catch(() => []),
+        computeClient.listRoutes().catch(() => []),
+      ]);
+      setSources(srcs);
+      setDevices(devs);
+      setManifests(mans);
+      setRoute(routes.find((r) => r.modelId === modelId && r.modality === modality) ?? null);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }, [modelId, modality]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const options: TargetOption[] = useMemo(
+    () => buildTargetOptions({ modality, modelId, sources, devices, manifests }),
+    [modality, modelId, sources, devices, manifests],
+  );
+  // Fallback list = concrete targets only (no "Auto").
+  const fallbackOptions = options.filter((o) => o.target !== "");
+
+  const primary = route?.primaryTarget ?? "";
+  const fallback = route?.fallbackTargets?.[0] ?? "";
+
+  // Live status for the currently-bound target.
+  function statusFor(target: string): { text: string; ok: boolean | null } {
+    if (!target) return { text: "Auto — routing policy decides", ok: null };
+    if (target === "local") return { text: "This PC", ok: null };
+    if (target.startsWith("device:")) {
+      const d = devices.find((x) => `device:${x.id}` === target);
+      const online = d ? (d.onlineEffective ?? d.online) : false;
+      return { text: `${targetLabel(target, sources, devices)} ${online ? "online" : "offline"}`, ok: online };
+    }
+    if (target.startsWith("source:")) {
+      const s = sources.find((x) => `source:${x.id}` === target);
+      return { text: `${targetLabel(target, sources, devices)} ${s?.enabled ? "enabled" : "disabled"}`, ok: !!s?.enabled };
+    }
+    return { text: targetLabel(target, sources, devices), ok: null };
+  }
+  const status = statusFor(primary);
+
+  const persist = useCallback(
+    async (nextPrimary: string, nextFallback: string) => {
+      setBusy(true);
+      setError(null);
+      try {
+        if (!nextPrimary) {
+          // Auto → clear the binding.
+          if (route) await computeClient.deleteRoute(modality, modelId);
+          setRoute(null);
+          onChange?.(null);
+        } else {
+          const saved = await computeClient.upsertRoute({
+            modality,
+            modelId,
+            primaryTarget: nextPrimary,
+            fallbackTargets: nextFallback ? [nextFallback] : [],
+            strategy: "pinned",
+            privacy: "private_nodes",
+          });
+          setRoute(saved);
+          onChange?.(saved);
+        }
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Save failed");
+      } finally {
+        setBusy(false);
+      }
+    },
+    [route, modality, modelId, onChange],
+  );
+
+  if (loading) return <Loader2 size={14} className="animate-spin text-white/40" />;
+
+  return (
+    <div className="flex flex-col gap-2 text-xs">
+      <div className="flex items-center gap-2 flex-wrap">
+        <span className="text-white/50">Runs on</span>
+        <Select
+          value={primary}
+          disabled={busy}
+          options={options}
+          onChange={(v) => void persist(v, fallback)}
+        />
+        <span className="text-white/50">Fallback</span>
+        <Select
+          value={fallback}
+          disabled={busy || !primary}
+          options={[{ target: "", label: "None" }, ...fallbackOptions.filter((o) => o.target !== primary)]}
+          onChange={(v) => void persist(primary, v)}
+        />
+        {busy && <Loader2 size={12} className="animate-spin text-white/40" />}
+      </div>
+      <div className="flex items-center gap-1.5 text-[11px]">
+        <span className="text-white/40">Status:</span>
+        <span
+          className={
+            status.ok === true ? "text-emerald-300" : status.ok === false ? "text-amber-300" : "text-white/50"
+          }
+        >
+          {status.text}
+        </span>
+      </div>
+      {error && <span className="text-red-300">{error}</span>}
+    </div>
+  );
+}
+
+function Select(props: {
+  value: string;
+  options: TargetOption[];
+  disabled?: boolean;
+  onChange: (v: string) => void;
+}) {
+  const { value, options, disabled, onChange } = props;
+  return (
+    <select
+      value={value}
+      disabled={disabled}
+      onChange={(e) => onChange(e.target.value)}
+      className="h-8 rounded-lg bg-black/40 border border-white/10 px-2 text-xs text-white outline-none focus:border-cyan-400/50 disabled:opacity-50"
+    >
+      {options.map((o) => (
+        <option key={o.target || "auto"} value={o.target} disabled={o.disabled}>
+          {o.label}
+          {o.disabled && o.reason ? ` — ${o.reason}` : ""}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/frontend/src/ui/components/compute/RouteBadge.test.tsx
+++ b/frontend/src/ui/components/compute/RouteBadge.test.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import RouteBadge from "./RouteBadge";
+
+describe("RouteBadge", () => {
+  it("stays hidden for a plain local reply (signal, not chrome)", () => {
+    const { container } = render(
+      <RouteBadge compute={{ target: "local", label: "This PC", fell_back: false }} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows which device served a remote reply", () => {
+    render(<RouteBadge compute={{ target: "device:colab", device_id: "colab", label: "Colab T4", fell_back: false }} />);
+    expect(screen.getByText(/Ran on Colab T4/)).toBeInTheDocument();
+  });
+
+  it("explains a fallback with its reason", () => {
+    render(
+      <RouteBadge
+        compute={{ target: "local", label: "This PC", fell_back: true, reason: "cloud unreachable" }}
+      />,
+    );
+    expect(screen.getByText(/Fell back to This PC/)).toBeInTheDocument();
+    expect(screen.getByText(/cloud unreachable/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/ui/components/compute/RouteBadge.tsx
+++ b/frontend/src/ui/components/compute/RouteBadge.tsx
@@ -1,0 +1,46 @@
+/**
+ * RouteBadge — a small "ran on <device>" chip under an assistant reply.
+ *
+ * Makes routing legible (design acceptance #7): the user can see which device
+ * served the response, and — when the primary target was offline — that it fell
+ * back, and why. Deliberately quiet: it stays hidden for plain local replies so
+ * it's signal, not chrome.
+ *
+ * Consumes the raw /chat `compute` block (snake_case; that endpoint isn't
+ * routed through the camelizing compute-client).
+ */
+import React from "react";
+import { Cpu, CornerDownRight } from "lucide-react";
+
+export interface RouteInfo {
+  target: string;
+  device_id?: string | null;
+  label: string;
+  fell_back: boolean;
+  reason?: string | null;
+}
+
+export default function RouteBadge({ compute }: { compute?: RouteInfo | null }) {
+  // Hide for the common local case — only surface remote or fallback routing.
+  if (!compute || (compute.target === "local" && !compute.fell_back)) return null;
+
+  if (compute.fell_back) {
+    return (
+      <span
+        title={compute.reason || undefined}
+        className="inline-flex items-center gap-1 text-[11px] text-amber-300/90 bg-amber-500/10 border border-amber-500/20 rounded-full px-2 py-0.5"
+      >
+        <CornerDownRight size={11} />
+        Fell back to {compute.label}
+        {compute.reason ? <span className="text-amber-300/50"> · {compute.reason}</span> : null}
+      </span>
+    );
+  }
+
+  return (
+    <span className="inline-flex items-center gap-1 text-[11px] text-white/45 bg-white/[0.04] border border-white/10 rounded-full px-2 py-0.5">
+      <Cpu size={11} />
+      Ran on {compute.label}
+    </span>
+  );
+}

--- a/frontend/src/ui/components/compute/RoutingPolicyEditor.tsx
+++ b/frontend/src/ui/components/compute/RoutingPolicyEditor.tsx
@@ -1,0 +1,298 @@
+/**
+ * RoutingPolicyEditor — the "Routing" tab.
+ *
+ * Three layers, matching the resolver's precedence:
+ *   1. Global compute mode (local / cloud / auto) — the ex-env flag, now a
+ *      persisted setting.
+ *   2. Per-model routes — explicit bindings that beat the defaults, each with a
+ *      live "how this resolves" preview from /compute/admin/resolve.
+ *   3. (Per-modality defaults are edited inline via the model routes' Auto.)
+ */
+import React, { useCallback, useEffect, useState } from "react";
+import { Loader2, Plus, Save, Trash2 } from "lucide-react";
+import type {
+  ComputeMode,
+  ComputeSettings,
+  ModelRoute,
+  RouteCost,
+  RouteResolution,
+} from "@homepilot/types";
+import { computeClient } from "../../api";
+import { MODALITIES } from "./targets";
+
+const MODES: { value: ComputeMode; label: string }[] = [
+  { value: "local", label: "This PC only" },
+  { value: "auto", label: "Auto (prefer local, burst to cloud)" },
+  { value: "ollabridge_cloud", label: "OllaBridge Cloud" },
+];
+
+function costLabel(c: RouteCost): string {
+  const price =
+    c.estimatedUsd == null
+      ? "cost unknown"
+      : c.estimatedUsd === 0
+        ? "free"
+        : `$${c.estimatedUsd.toFixed(2)}/${c.perUnit || "request"}`;
+  return `${c.target}: ${price}${c.overBudget ? " (over budget)" : ""}`;
+}
+
+export default function RoutingPolicyEditor() {
+  const [settings, setSettings] = useState<ComputeSettings | null>(null);
+  const [routes, setRoutes] = useState<ModelRoute[]>([]);
+  const [resolutions, setResolutions] = useState<Record<string, RouteResolution>>({});
+  const [draft, setDraft] = useState<{ modality: string; modelId: string; primaryTarget: string; fallback: string } | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [s, r] = await Promise.all([
+        computeClient.getComputeSettings(),
+        computeClient.listRoutes(),
+      ]);
+      setSettings(s);
+      setRoutes(r);
+      const entries = await Promise.all(
+        r.map(async (route) => {
+          try {
+            return [`${route.modality}:${route.modelId}`, await computeClient.resolveRoute(route.modality, route.modelId)] as const;
+          } catch {
+            return null;
+          }
+        }),
+      );
+      setResolutions(Object.fromEntries(entries.filter(Boolean) as [string, RouteResolution][]));
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load routing");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const saveMode = useCallback(async (mode: ComputeMode) => {
+    setBusy(true);
+    try {
+      setSettings(await computeClient.putComputeSettings({ computeMode: mode }));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Save failed");
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  const saveBudget = useCallback(async (value: string) => {
+    const parsed = value.trim() === "" ? null : Number(value);
+    if (parsed != null && (Number.isNaN(parsed) || parsed < 0)) return;
+    setBusy(true);
+    try {
+      setSettings(await computeClient.putComputeSettings({ maxCostUsdPerRequest: parsed }));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Save failed");
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  const addRoute = useCallback(async () => {
+    if (!draft) return;
+    if (!draft.modelId.trim() || !draft.primaryTarget.trim()) {
+      setError("Model id and primary target are required.");
+      return;
+    }
+    setBusy(true);
+    try {
+      await computeClient.upsertRoute({
+        modality: draft.modality as ModelRoute["modality"],
+        modelId: draft.modelId.trim(),
+        primaryTarget: draft.primaryTarget.trim(),
+        fallbackTargets: draft.fallback.trim() ? [draft.fallback.trim()] : [],
+        strategy: "pinned",
+        privacy: "private_nodes",
+      });
+      setDraft(null);
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Save failed");
+    } finally {
+      setBusy(false);
+    }
+  }, [draft, load]);
+
+  const removeRoute = useCallback(
+    async (route: ModelRoute) => {
+      await computeClient.deleteRoute(route.modality, route.modelId);
+      await load();
+    },
+    [load],
+  );
+
+  if (loading) return <Loader2 size={16} className="animate-spin text-white/40" />;
+
+  return (
+    <div className="space-y-5">
+      {error && (
+        <div className="px-3 py-2 rounded-xl bg-red-500/10 border border-red-500/20 text-red-300 text-xs">
+          {error}
+        </div>
+      )}
+
+      {/* Global default */}
+      <div className="rounded-2xl border border-white/10 bg-white/[0.02] p-4 space-y-2">
+        <div className="text-sm font-semibold text-white">Default compute</div>
+        <p className="text-xs text-white/50">Used when a model has no explicit route.</p>
+        <div className="flex flex-wrap gap-2 pt-1">
+          {MODES.map((m) => (
+            <button
+              key={m.value}
+              disabled={busy}
+              onClick={() => void saveMode(m.value)}
+              className={`h-9 px-3 rounded-xl border text-xs ${
+                settings?.computeMode === m.value
+                  ? "bg-cyan-500/20 border-cyan-400/30 text-cyan-100"
+                  : "bg-white/5 border-white/10 text-white/60 hover:bg-white/10"
+              }`}
+            >
+              {m.label}
+            </button>
+          ))}
+        </div>
+        <label className="flex items-center gap-2 pt-2 text-xs text-white/60">
+          <span>Budget per request (USD)</span>
+          <input
+            type="number"
+            min={0}
+            step="0.01"
+            defaultValue={settings?.maxCostUsdPerRequest ?? ""}
+            placeholder="no cap"
+            onBlur={(e) => void saveBudget(e.target.value)}
+            className="h-8 w-28 rounded-lg bg-black/40 border border-white/10 px-2 text-xs text-white outline-none focus:border-cyan-400/50"
+          />
+          <span className="text-white/30">hosted options over budget are skipped</span>
+        </label>
+      </div>
+
+      {/* Per-model routes */}
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <div className="text-sm font-semibold text-white">Per-model routes</div>
+          <button
+            onClick={() => setDraft({ modality: "chat", modelId: "", primaryTarget: "local", fallback: "" })}
+            className="h-9 px-3 rounded-xl bg-white/5 hover:bg-white/10 border border-white/10 text-xs text-white/70 inline-flex items-center gap-1.5"
+          >
+            <Plus size={14} /> Add route
+          </button>
+        </div>
+
+        <ul className="space-y-2">
+          {routes.map((r) => {
+            const res = resolutions[`${r.modality}:${r.modelId}`];
+            return (
+              <li key={`${r.modality}:${r.modelId}`} className="rounded-2xl border border-white/10 bg-white/[0.02] p-4">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <div className="text-sm text-white">
+                      {r.modelId} <span className="text-white/40">· {r.modality}</span>
+                    </div>
+                    <div className="text-xs text-white/50">
+                      {r.primaryTarget}
+                      {r.fallbackTargets.length ? ` → ${r.fallbackTargets.join(" → ")}` : ""}
+                      <span className="text-white/30"> · {r.strategy}</span>
+                    </div>
+                    {res && (
+                      <div className="text-[11px] text-white/40 mt-1">
+                        Resolves to: {res.targets.join(" → ")}
+                        {res.costs?.length ? (
+                          <span className="block text-white/30">
+                            {res.costs.map(costLabel).join(" · ")}
+                          </span>
+                        ) : null}
+                      </div>
+                    )}
+                  </div>
+                  <button
+                    onClick={() => void removeRoute(r)}
+                    aria-label={`Delete route for ${r.modelId}`}
+                    className="h-8 w-8 grid place-items-center rounded-xl bg-white/5 hover:bg-red-500/10 border border-white/10 text-white/50 hover:text-red-300"
+                  >
+                    <Trash2 size={14} />
+                  </button>
+                </div>
+              </li>
+            );
+          })}
+          {routes.length === 0 && <li className="text-xs text-white/40">No per-model routes.</li>}
+        </ul>
+
+        {draft && (
+          <div className="rounded-2xl border border-white/10 bg-black/30 p-4 space-y-3">
+            <div className="grid grid-cols-2 gap-3">
+              <label className="block space-y-1">
+                <span className="text-xs text-white/50">Modality</span>
+                <select
+                  value={draft.modality}
+                  onChange={(e) => setDraft({ ...draft, modality: e.target.value })}
+                  className="w-full h-10 rounded-xl bg-black/40 border border-white/10 px-3 text-sm text-white outline-none focus:border-cyan-400/50"
+                >
+                  {MODALITIES.map((m) => (
+                    <option key={m} value={m}>
+                      {m}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="block space-y-1">
+                <span className="text-xs text-white/50">Model id</span>
+                <input
+                  value={draft.modelId}
+                  onChange={(e) => setDraft({ ...draft, modelId: e.target.value })}
+                  placeholder="deepseek-r1:latest"
+                  className="w-full h-10 rounded-xl bg-black/40 border border-white/10 px-3 text-sm text-white placeholder:text-white/30 outline-none focus:border-cyan-400/50"
+                />
+              </label>
+              <label className="block space-y-1">
+                <span className="text-xs text-white/50">Primary target</span>
+                <input
+                  value={draft.primaryTarget}
+                  onChange={(e) => setDraft({ ...draft, primaryTarget: e.target.value })}
+                  placeholder="local · device:colab · source:my-vllm"
+                  className="w-full h-10 rounded-xl bg-black/40 border border-white/10 px-3 text-sm text-white placeholder:text-white/30 outline-none focus:border-cyan-400/50"
+                />
+              </label>
+              <label className="block space-y-1">
+                <span className="text-xs text-white/50">Fallback (optional)</span>
+                <input
+                  value={draft.fallback}
+                  onChange={(e) => setDraft({ ...draft, fallback: e.target.value })}
+                  placeholder="local"
+                  className="w-full h-10 rounded-xl bg-black/40 border border-white/10 px-3 text-sm text-white placeholder:text-white/30 outline-none focus:border-cyan-400/50"
+                />
+              </label>
+            </div>
+            <div className="flex items-center gap-2 justify-end">
+              <button
+                onClick={() => setDraft(null)}
+                className="h-9 px-3 rounded-xl bg-white/5 hover:bg-white/10 border border-white/10 text-xs text-white/60"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => void addRoute()}
+                disabled={busy}
+                className="h-9 px-3 rounded-xl bg-cyan-500/20 hover:bg-cyan-500/30 border border-cyan-400/30 text-xs text-cyan-100 inline-flex items-center gap-1.5 disabled:opacity-50"
+              >
+                {busy ? <Loader2 size={14} className="animate-spin" /> : <Save size={14} />} Save
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/ui/components/compute/targets.test.ts
+++ b/frontend/src/ui/components/compute/targets.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { buildTargetOptions, targetLabel } from "./targets";
+import type { ComputeDevice, ComputeSource, ModelManifest } from "@homepilot/types";
+
+const device = (over: Partial<ComputeDevice>): ComputeDevice => ({
+  id: "d",
+  sourceId: "ob",
+  name: "Colab T4",
+  online: true,
+  ephemeral: true,
+  capacity: 1,
+  activeJobs: 0,
+  ...over,
+});
+
+describe("targetLabel", () => {
+  it("maps well-known and dynamic targets to labels", () => {
+    const sources = [{ id: "oa", name: "My vLLM" } as ComputeSource];
+    const devices = [device({ id: "colab", name: "Colab T4" })];
+    expect(targetLabel("local")).toBe("This PC");
+    expect(targetLabel("ollabridge_cloud")).toContain("OllaBridge Cloud");
+    expect(targetLabel("device:colab", sources, devices)).toBe("Colab T4");
+    expect(targetLabel("source:oa", sources, devices)).toBe("My vLLM");
+  });
+});
+
+describe("buildTargetOptions", () => {
+  it("always offers Auto and This PC first", () => {
+    const opts = buildTargetOptions({ modality: "chat", sources: [], devices: [], manifests: [] });
+    expect(opts[0].label).toBe("Auto");
+    expect(opts[1].target).toBe("local");
+  });
+
+  it("disables an offline device with a reason", () => {
+    const opts = buildTargetOptions({
+      modality: "chat",
+      modelId: "m",
+      sources: [],
+      devices: [device({ id: "colab", online: false, onlineEffective: false })],
+      manifests: [],
+    });
+    const colab = opts.find((o) => o.target === "device:colab")!;
+    expect(colab.disabled).toBe(true);
+    expect(colab.reason).toBe("Offline");
+  });
+
+  it("disables a device without enough VRAM", () => {
+    const manifests: ModelManifest[] = [
+      { id: "big", runtime: "comfyui", capabilities: ["image"], deviceIds: ["colab"], minimumVramMb: 20000 },
+    ];
+    const opts = buildTargetOptions({
+      modality: "image",
+      modelId: "big",
+      sources: [],
+      devices: [device({ id: "colab", vramMb: 8000 })],
+      manifests,
+    });
+    const colab = opts.find((o) => o.target === "device:colab")!;
+    expect(colab.disabled).toBe(true);
+    expect(colab.reason).toContain("GB VRAM");
+  });
+
+  it("marks an OpenAI-compatible source chat-only for image requests", () => {
+    const sources: ComputeSource[] = [
+      { id: "oa", name: "vLLM", kind: "openai_compatible", enabled: true, executionType: "direct" },
+    ];
+    const opts = buildTargetOptions({ modality: "image", sources, devices: [], manifests: [] });
+    const oa = opts.find((o) => o.target === "source:oa")!;
+    expect(oa.disabled).toBe(true);
+    expect(oa.reason).toBe("Chat only");
+  });
+});

--- a/frontend/src/ui/components/compute/targets.ts
+++ b/frontend/src/ui/components/compute/targets.ts
@@ -1,0 +1,119 @@
+// Shared helpers for the Compute Sources & Routing UI — turning routing target
+// strings (see backend app/compute/policies.py) into human labels and building
+// the per-model execution options. Kept framework-free so components stay thin.
+
+import type { ComputeDevice, ComputeSource, Modality, ModelManifest } from "@homepilot/types";
+
+export const MODALITIES: Modality[] = ["chat", "multimodal", "image", "video", "edit"];
+
+/** A selectable execution target for a model, with disabled reasoning. */
+export interface TargetOption {
+  target: string;
+  label: string;
+  detail?: string;
+  disabled?: boolean;
+  reason?: string;
+}
+
+const MODALITY_CAPABILITY: Record<Modality, string> = {
+  chat: "chat",
+  multimodal: "multimodal",
+  image: "image",
+  video: "video",
+  edit: "edit",
+};
+
+/** Human label for a target string. Falls back to the raw string. */
+export function targetLabel(
+  target: string,
+  sources: ComputeSource[] = [],
+  devices: ComputeDevice[] = [],
+): string {
+  if (target === "local") return "This PC";
+  if (target === "ollabridge_cloud" || target === "ollabridge:any")
+    return "OllaBridge Cloud (any node)";
+  if (target.startsWith("device:")) {
+    const id = target.slice("device:".length);
+    return devices.find((d) => d.id === id)?.name || `Device ${id}`;
+  }
+  if (target.startsWith("source:")) {
+    const id = target.slice("source:".length);
+    return sources.find((s) => s.id === id)?.name || `Source ${id}`;
+  }
+  if (target.startsWith("provider:")) return `Provider ${target.slice("provider:".length)}`;
+  return target;
+}
+
+/**
+ * Build the execution options for a (model, modality). Always offers Auto and
+ * This PC; adds each online device and enabled remote source, disabling any that
+ * can't serve the request and explaining why (the design's "Unavailable: …").
+ */
+export function buildTargetOptions(args: {
+  modality: Modality;
+  modelId?: string;
+  sources: ComputeSource[];
+  devices: ComputeDevice[];
+  manifests: ModelManifest[];
+}): TargetOption[] {
+  const { modality, modelId, sources, devices, manifests } = args;
+  const manifest = modelId ? manifests.find((m) => m.id === modelId) : undefined;
+  const need = MODALITY_CAPABILITY[modality];
+
+  const options: TargetOption[] = [
+    { target: "", label: "Auto", detail: "Use the routing policy" },
+    { target: "local", label: "This PC", detail: "Private GPU" },
+  ];
+
+  for (const d of devices) {
+    const online = d.onlineEffective ?? d.online;
+    const opt: TargetOption = {
+      target: `device:${d.id}`,
+      label: d.name || d.id,
+      detail: [d.gpuName, d.vramMb ? `${Math.round(d.vramMb / 1024)} GB` : null]
+        .filter(Boolean)
+        .join(" · "),
+    };
+    if (!online) {
+      opt.disabled = true;
+      opt.reason = "Offline";
+    } else if (manifest && manifest.deviceIds.length && !manifest.deviceIds.includes(d.id)) {
+      opt.disabled = true;
+      opt.reason = "Model not installed";
+    } else if (manifest && need && manifest.capabilities.length && !manifest.capabilities.includes(need as never)) {
+      opt.disabled = true;
+      opt.reason = `No ${modality} capability`;
+    } else if (
+      manifest?.minimumVramMb &&
+      d.vramMb != null &&
+      d.vramMb < manifest.minimumVramMb
+    ) {
+      opt.disabled = true;
+      opt.reason = `Requires ${Math.round(manifest.minimumVramMb / 1024)} GB VRAM`;
+    }
+    options.push(opt);
+  }
+
+  for (const s of sources) {
+    if (s.kind === "local") continue; // already represented by "This PC"
+    const opt: TargetOption = {
+      target: `source:${s.id}`,
+      label: s.name || s.id,
+      detail: s.kind,
+    };
+    if (!s.enabled) {
+      opt.disabled = true;
+      opt.reason = "Disabled";
+    } else if (
+      (s.kind === "openai_compatible" || s.kind === "huggingface") &&
+      modality !== "chat" &&
+      modality !== "multimodal"
+    ) {
+      opt.disabled = true;
+      opt.reason = "Chat only";
+    }
+    options.push(opt);
+  }
+
+  return options;
+}

--- a/frontend/src/ui/lib/streamChat.test.ts
+++ b/frontend/src/ui/lib/streamChat.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+import { parseSseBuffer, streamChat } from "./streamChat";
+
+describe("parseSseBuffer", () => {
+  it("splits complete frames and keeps the remainder", () => {
+    const { frames, rest } = parseSseBuffer(
+      'data: {"delta":"a"}\n\ndata: {"delta":"b"}\n\ndata: {"del',
+    );
+    expect(frames).toEqual([{ delta: "a" }, { delta: "b" }]);
+    expect(rest).toBe('data: {"del');
+  });
+});
+
+function sseStream(chunks: string[]): ReadableStream<Uint8Array> {
+  const enc = new TextEncoder();
+  let i = 0;
+  return new ReadableStream({
+    pull(controller) {
+      if (i < chunks.length) controller.enqueue(enc.encode(chunks[i++]));
+      else controller.close();
+    },
+  });
+}
+
+describe("streamChat", () => {
+  it("delivers deltas in order and the final route info", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () =>
+      new Response(
+        sseStream([
+          'data: {"delta":"Hi"}\n\n',
+          'data: {"delta":" there"}\n\n',
+          'data: {"done":true,"compute":{"target":"device:colab","label":"Colab T4","fell_back":false}}\n\n',
+        ]),
+        { status: 200, headers: { "content-type": "text/event-stream" } },
+      ),
+    ));
+
+    const deltas: string[] = [];
+    let compute: any = null;
+    await streamChat("http://x", { messages: [{ role: "user", content: "hi" }] }, {
+      onDelta: (t) => deltas.push(t),
+      onDone: (c) => (compute = c),
+    });
+
+    expect(deltas.join("")).toBe("Hi there");
+    expect(compute).toMatchObject({ label: "Colab T4" });
+    vi.unstubAllGlobals();
+  });
+
+  it("reports an error frame", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () =>
+      new Response(sseStream(['data: {"error":"cloud unreachable"}\n\n', 'data: {"done":true,"compute":null}\n\n']), {
+        status: 200,
+      }),
+    ));
+    const errors: string[] = [];
+    await streamChat("http://x", { messages: [] }, { onDelta: () => {}, onError: (e) => errors.push(e) });
+    expect(errors).toEqual(["cloud unreachable"]);
+    vi.unstubAllGlobals();
+  });
+});

--- a/frontend/src/ui/lib/streamChat.ts
+++ b/frontend/src/ui/lib/streamChat.ts
@@ -1,0 +1,91 @@
+/**
+ * streamChat — consume the /v1/compute/chat/stream SSE endpoint (P1).
+ *
+ * Reads token deltas as they arrive (live typewriter) and hands back the final
+ * route diagnostics (which device served the reply). Frame format, one JSON
+ * object per `data:` line:
+ *   {delta:"..."} | {error:"..."} | {done:true, compute:{...}}
+ */
+
+export interface RouteInfo {
+  target: string;
+  device_id?: string | null;
+  label: string;
+  fell_back: boolean;
+  reason?: string | null;
+}
+
+export interface StreamChatBody {
+  messages: Array<{ role: string; content: string }>;
+  model?: string;
+  provider?: string;
+  modality?: string;
+  base_url?: string;
+  temperature?: number;
+  max_tokens?: number;
+}
+
+export interface StreamChatCallbacks {
+  onDelta: (text: string) => void;
+  onDone?: (compute: RouteInfo | null) => void;
+  onError?: (message: string) => void;
+}
+
+/** Split a raw SSE buffer into complete frames, returning [frames, remainder]. */
+export function parseSseBuffer(buffer: string): { frames: unknown[]; rest: string } {
+  const frames: unknown[] = [];
+  let rest = buffer;
+  let idx: number;
+  while ((idx = rest.indexOf("\n\n")) >= 0) {
+    const block = rest.slice(0, idx);
+    rest = rest.slice(idx + 2);
+    const dataLine = block.split("\n").find((l) => l.startsWith("data:"));
+    if (!dataLine) continue;
+    const payload = dataLine.slice("data:".length).trim();
+    if (!payload) continue;
+    try {
+      frames.push(JSON.parse(payload));
+    } catch {
+      /* ignore malformed frame */
+    }
+  }
+  return { frames, rest };
+}
+
+function dispatch(frame: any, cb: StreamChatCallbacks): void {
+  if (frame == null) return;
+  if (typeof frame.delta === "string") cb.onDelta(frame.delta);
+  else if (typeof frame.error === "string") cb.onError?.(frame.error);
+  else if (frame.done) cb.onDone?.((frame.compute as RouteInfo) ?? null);
+}
+
+export async function streamChat(
+  baseUrl: string,
+  body: StreamChatBody,
+  cb: StreamChatCallbacks,
+  opts: { signal?: AbortSignal; headers?: Record<string, string> } = {},
+): Promise<void> {
+  const res = await fetch(`${baseUrl.replace(/\/+$/, "")}/v1/compute/chat/stream`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...(opts.headers || {}) },
+    body: JSON.stringify(body),
+    signal: opts.signal,
+  });
+  if (!res.ok || !res.body) {
+    throw new Error(`Streaming request failed (HTTP ${res.status}).`);
+  }
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const { frames, rest } = parseSseBuffer(buffer);
+    buffer = rest;
+    for (const f of frames) dispatch(f, cb);
+  }
+  // Flush any trailing frame without the final blank line.
+  const { frames } = parseSseBuffer(buffer + "\n\n");
+  for (const f of frames) dispatch(f, cb);
+}

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -30,6 +30,7 @@ export interface ApiClient {
   get<T>(path: string): Promise<T>;
   post<T>(path: string, body?: unknown): Promise<T>;
   put<T>(path: string, body?: unknown): Promise<T>;
+  del<T>(path: string): Promise<T>;
 }
 
 export class ApiError extends Error {
@@ -70,6 +71,7 @@ export function createClient(opts: ClientOptions): ApiClient {
     get: (path) => request("GET", path),
     post: (path, body) => request("POST", path, body),
     put: (path, body) => request("PUT", path, body),
+    del: (path) => request("DELETE", path),
   };
 }
 

--- a/packages/compute-client/src/index.ts
+++ b/packages/compute-client/src/index.ts
@@ -8,7 +8,22 @@
 // polyfill or polling on mobile), keeping this module platform-pure.
 
 import type { ApiClient } from "@homepilot/api-client";
-import type { Device, Job, JobEvent, ComputeStatus, SupplierPolicy } from "@homepilot/types";
+import type {
+  Device,
+  Job,
+  JobEvent,
+  ComputeStatus,
+  SupplierPolicy,
+  ComputeSource,
+  ComputeDevice,
+  ModelManifest,
+  ModelRoute,
+  ComputeSettings,
+  RouteResolution,
+  LocalResources,
+  SourceTestResult,
+  CloudSyncResult,
+} from "@homepilot/types";
 
 export interface ImageJobInput {
   model?: string;
@@ -46,6 +61,34 @@ export interface ComputeClient {
   listUserDevices(): Promise<Device[]>;
   getDevicePolicy(deviceId: string): Promise<SupplierPolicy>;
   setDevicePolicy(deviceId: string, policy: Partial<SupplierPolicy>): Promise<SupplierPolicy>;
+
+  // PR 2/3 — Compute Sources & Routing admin (/compute/admin/*)
+  listComputeSources(): Promise<ComputeSource[]>;
+  /** Upsert a source. Pass `credential` to store a secret out-of-band (write-only). */
+  upsertComputeSource(
+    source: Partial<ComputeSource> & { id: string; credential?: string },
+  ): Promise<ComputeSource>;
+  deleteComputeSource(id: string): Promise<void>;
+  setSourceCredential(id: string, credential: string): Promise<{ credentialRef: string }>;
+  testComputeSource(id: string): Promise<SourceTestResult>;
+
+  listComputeDevices(sourceId?: string): Promise<ComputeDevice[]>;
+  getLocalResources(): Promise<LocalResources>;
+  /** Pull paired devices + advertised models from OllaBridge Cloud into the registry. */
+  syncFromCloud(): Promise<CloudSyncResult>;
+
+  listModelManifests(): Promise<ModelManifest[]>;
+  upsertModelManifest(manifest: ModelManifest): Promise<ModelManifest>;
+  deleteModelManifest(id: string): Promise<void>;
+
+  listRoutes(): Promise<ModelRoute[]>;
+  upsertRoute(route: ModelRoute): Promise<ModelRoute>;
+  deleteRoute(modality: string, modelId: string): Promise<void>;
+
+  getComputeSettings(): Promise<ComputeSettings>;
+  putComputeSettings(patch: Partial<ComputeSettings>): Promise<ComputeSettings>;
+
+  resolveRoute(modality: string, modelId?: string): Promise<RouteResolution>;
 }
 
 export function createComputeClient(api: ApiClient): ComputeClient {
@@ -58,6 +101,7 @@ export function createComputeClient(api: ApiClient): ComputeClient {
     api.post<unknown>(path, body).then((r) => camelize(r) as T);
   const put = <T>(path: string, body?: unknown) =>
     api.put<unknown>(path, body).then((r) => camelize(r) as T);
+  const del = (path: string) => api.del<unknown>(path).then(() => undefined);
 
   return {
     createImageJob: (input) => post<Job>("/v1/images/generations", toSnake(input)),
@@ -70,6 +114,61 @@ export function createComputeClient(api: ApiClient): ComputeClient {
     getDevicePolicy: (deviceId) => get<SupplierPolicy>(`/v1/devices/${deviceId}/policy`),
     setDevicePolicy: (deviceId, policy) =>
       put<SupplierPolicy>(`/v1/devices/${deviceId}/policy`, toSnake(policy)),
+
+    // --- Compute admin ---
+    listComputeSources: () =>
+      get<{ sources: ComputeSource[] }>("/compute/admin/sources").then((r) => r.sources),
+    upsertComputeSource: (source) =>
+      post<{ source: ComputeSource }>("/compute/admin/sources", deepSnake(source)).then(
+        (r) => r.source,
+      ),
+    deleteComputeSource: (id) => del(`/compute/admin/sources/${encodeURIComponent(id)}`),
+    setSourceCredential: (id, credential) =>
+      post<{ credentialRef: string }>(
+        `/compute/admin/sources/${encodeURIComponent(id)}/credential`,
+        { credential },
+      ),
+    testComputeSource: (id) =>
+      post<SourceTestResult>(`/compute/admin/sources/${encodeURIComponent(id)}/test`),
+
+    listComputeDevices: (sourceId) =>
+      get<{ devices: ComputeDevice[] }>(
+        `/compute/admin/devices${sourceId ? `?source_id=${encodeURIComponent(sourceId)}` : ""}`,
+      ).then((r) => r.devices),
+    getLocalResources: () => get<LocalResources>("/v1/system/resources"),
+    syncFromCloud: () => post<CloudSyncResult>("/compute/admin/sync"),
+
+    listModelManifests: () =>
+      get<{ models: ModelManifest[] }>("/compute/admin/models").then((r) => r.models),
+    upsertModelManifest: (manifest) =>
+      post<{ model: ModelManifest }>("/compute/admin/models", deepSnake(manifest)).then(
+        (r) => r.model,
+      ),
+    deleteModelManifest: (id) => del(`/compute/admin/models/${encodeURIComponent(id)}`),
+
+    listRoutes: () =>
+      get<{ routes: ModelRoute[] }>("/compute/admin/routes").then((r) => r.routes),
+    upsertRoute: (route) =>
+      post<{ route: ModelRoute }>("/compute/admin/routes", deepSnake(route)).then(
+        (r) => r.route,
+      ),
+    deleteRoute: (modality, modelId) =>
+      del(
+        `/compute/admin/routes/${encodeURIComponent(modality)}/${encodeURIComponent(modelId)}`,
+      ),
+
+    getComputeSettings: () =>
+      get<{ settings: ComputeSettings }>("/compute/admin/settings").then((r) => r.settings),
+    putComputeSettings: (patch) =>
+      put<{ settings: ComputeSettings }>("/compute/admin/settings", deepSnake(patch)).then(
+        (r) => r.settings,
+      ),
+
+    resolveRoute: (modality, modelId) =>
+      get<RouteResolution>(
+        `/compute/admin/resolve?modality=${encodeURIComponent(modality)}` +
+          (modelId ? `&model_id=${encodeURIComponent(modelId)}` : ""),
+      ),
   };
 }
 
@@ -97,4 +196,21 @@ function toSnake(obj: object): Record<string, unknown> {
     out[key.replace(/[A-Z]/g, (m) => `_${m.toLowerCase()}`)] = value;
   }
   return out;
+}
+
+const snakeKey = (key: string): string => key.replace(/[A-Z]/g, (m) => `_${m.toLowerCase()}`);
+
+/** Recursive camelCase → snake_case for nested request bodies (e.g. compute
+ * settings with per-modality defaults). Arrays and primitives pass through. */
+function deepSnake(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(deepSnake);
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (v === undefined) continue;
+      out[snakeKey(k)] = deepSnake(v);
+    }
+    return out;
+  }
+  return value;
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -81,6 +81,162 @@ export interface SupplierPolicy {
   paused: boolean;
 }
 
+// --- Compute Sources & Routing (HomePilot PR 2/3 /compute/admin/*) ---
+// camelCase mirror of app/compute/schemas.py. The wire is snake_case; the
+// compute-client normalizes both directions so every app codes against these.
+
+export type SourceKind =
+  | "local"
+  | "ollabridge"
+  | "openai_compatible"
+  | "comfyui"
+  | "huggingface"
+  | "runpod"
+  | "custom";
+export type ExecutionType = "local" | "direct" | "relay";
+export type ComputeRuntime = "ollama" | "vllm" | "comfyui" | "openai_api";
+export type Capability = "chat" | "vision" | "image" | "video" | "edit" | "multimodal";
+export type Modality = "chat" | "multimodal" | "image" | "video" | "edit";
+export type RouteStrategy = "pinned" | "prefer_local" | "prefer_remote" | "lowest_cost";
+export type RoutePrivacy = "local_only" | "private_nodes" | "hosted_allowed";
+
+export interface ComputeSource {
+  id: string;
+  name: string;
+  kind: SourceKind;
+  baseUrl?: string;
+  /** Opaque handle into the server-side secret store — never the secret itself. */
+  credentialRef?: string;
+  enabled: boolean;
+  executionType: ExecutionType;
+  meta?: Record<string, unknown>;
+}
+
+/** Richer than the Batch-8 `Device`: carries capacity/heartbeat for routing. */
+export interface ComputeDevice {
+  id: string;
+  sourceId: string;
+  name: string;
+  online: boolean;
+  ephemeral: boolean;
+  gpuName?: string;
+  vramMb?: number;
+  utilization?: number;
+  capacity: number;
+  activeJobs: number;
+  lastHeartbeat?: number;
+  /** Server-computed: online AND heartbeat within TTL. */
+  onlineEffective?: boolean;
+  heartbeatAgeS?: number;
+}
+
+export interface ModelManifest {
+  id: string;
+  runtime: ComputeRuntime;
+  capabilities: Capability[];
+  deviceIds: string[];
+  digest?: string;
+  minimumVramMb?: number;
+  workflowVersion?: string;
+}
+
+export interface ModelRoute {
+  modality: Modality;
+  modelId: string;
+  primaryTarget: string;
+  fallbackTargets: string[];
+  strategy: RouteStrategy;
+  maxQueueSeconds?: number;
+  maxCostUsd?: number;
+  privacy: RoutePrivacy;
+}
+
+export interface ModalityDefault {
+  modality: Modality;
+  strategy: RouteStrategy;
+  target?: string;
+  fallbackTargets: string[];
+  privacy: RoutePrivacy;
+}
+
+export interface ComputeSettings {
+  computeMode: ComputeMode;
+  burstRequiresPremium: boolean;
+  premiumEnabled: boolean;
+  cloudUrl?: string;
+  cloudImageModel: string;
+  cloudVideoModel: string;
+  deviceHeartbeatTtlS: number;
+  modalityDefaults: Record<string, ModalityDefault>;
+  /** PR 5 — per-request USD budget (null = no cap) + a timestamped price map. */
+  maxCostUsdPerRequest?: number | null;
+  costCatalog?: Record<string, unknown>;
+}
+
+/** A local GPU from /v1/system/resources (multi-GPU aware). */
+export interface LocalGpu {
+  index?: number;
+  available: boolean;
+  name?: string | null;
+  vramTotalMb?: number | null;
+  vramUsedMb?: number | null;
+  usedPercent?: number | null;
+  utilizationPercent?: number | null;
+  temperatureC?: number | null;
+  status?: string;
+}
+
+/** Local machine capacity (GPUs + CPU + RAM) for the Resources panel. */
+export interface LocalResources {
+  gpu: LocalGpu;
+  gpus: LocalGpu[];
+  cpu: { name?: string | null; physicalCores?: number; logicalCores?: number; percent?: number };
+  ram: { totalMb?: number; usedMb?: number; percent?: number };
+}
+
+/** Result of probing a source's reachability. */
+export interface SourceTestResult {
+  ok: boolean;
+  reason?: string;
+}
+
+/** Result of syncing paired devices + models from OllaBridge Cloud. */
+export interface CloudSyncResult {
+  ok: boolean;
+  linked: boolean;
+  devices: number;
+  models: number;
+  reason?: string;
+  sourceId?: string;
+}
+
+/** Timestamped, per-target cost estimate (provider prices aren't hardcoded). */
+export interface CostEstimate {
+  target: string;
+  currency: string;
+  estimatedUsd?: number | null;
+  perUnit?: string;
+  asOf?: string;
+  note?: string;
+}
+
+/** A cost estimate as it appears in a route explanation. */
+export interface RouteCost extends CostEstimate {
+  overBudget: boolean;
+  selected: boolean;
+}
+
+/** What `/compute/admin/resolve` returns — how a request would be routed. */
+export interface RouteResolution {
+  modality: Modality;
+  modelId?: string;
+  matched: "route" | "modality_default" | "global_default";
+  computeMode: ComputeMode;
+  targets: string[];
+  budgetUsd?: number | null;
+  costs?: RouteCost[];
+}
+
 // --- Product domain ---
 export interface Persona {
   id: string;


### PR DESCRIPTION
compute: surface the selected device in chat diagnostics (P0-2)
Makes routing legible (design acceptance https://github.com/ruslanmv/HomePilot/pull/7): the user sees which device served
a reply, and when the primary target was offline, that it fell back and why.

Backend:
- ComputeRouter._dispatch records a route report — the winning target, its
  device_id, whether it fell back, the failed attempts and the first failure's
  reason. route_chat()/chat() accept an optional `report` dict to receive it.
- describe_target() resolves a target to a human label ("Colab T4", "This PC",
  "OllaBridge Cloud", a source name) via the registry; build_diagnostics()
  shapes the report into the `compute` block.
- orchestrate() returns `compute` in the /chat response (additive).

Frontend:
- RouteBadge: a quiet chip under an assistant reply — "Ran on Colab T4", or an
  amber "Fell back to This PC · <reason>". Hidden for plain local replies so it's
  signal, not chrome. App threads `compute` onto the assistant message.

Tests: report records local winner + device-labelled fallback with reason;
RouteBadge hides/show/fallback states. Backend compute 45 green; frontend 148
green; typecheck clean.