### PR TITLE
Compute sources routing

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -35,6 +35,11 @@ COPY frontend/ ./
 # WORKDIR is /build, so ../packages must be present at /packages. These are
 # TS source, not npm deps — npm ci above is unchanged.
 COPY packages/ /packages/
+# Each package's tsconfig.json does `"extends": "../../tsconfig.base.json"`,
+# which resolves to /tsconfig.base.json. esbuild reads it while transforming the
+# @homepilot/* package sources, so the base config must be present in the image
+# too — otherwise the build fails with `failed to resolve "extends"`.
+COPY tsconfig.base.json /tsconfig.base.json
 # Frontend build-time flags (Vite bakes ``import.meta.env.VITE_*`` at build).
 # Empty defaults preserve today's behavior (all OFF); pass build-args to opt in.
 #   VITE_ACCOUNTS_UX=1        → mount the OllaBridge account/computers UX


### PR DESCRIPTION
container: copy tsconfig.base.json into the frontend build stage (fix GHCR build)
The frontend-builder stage copies packages/ → /packages/, and each package's
tsconfig.json does `"extends": "../../tsconfig.base.json"` → /tsconfig.base.json.
esbuild reads that tsconfig while transforming the @homepilot/* package sources
during `vite build`, but the root base config was never copied into the image, so
the container build failed:

    [vite:esbuild] failed to resolve "extends":"../../tsconfig.base.json"
    in /packages/api-client/tsconfig.json

Add `COPY tsconfig.base.json /tsconfig.base.json` so the extends resolves — the
same path the local build already uses (verified: `vite build` transforms all
2183 modules and succeeds). The base config is self-contained (no further
extends), so one file fixes every package.
